### PR TITLE
[refactor] Store usage info in class statics

### DIFF
--- a/pkgs/cli/src/command.ts
+++ b/pkgs/cli/src/command.ts
@@ -1,0 +1,65 @@
+import Dist from './commands/dist.js';
+import CrossDist from './commands/cross-dist.js';
+import CrossPack from './commands/cross-pack.js';
+import CrossInstall from './commands/cross-install.js';
+import Help from './commands/help.js';
+
+export interface Command {
+  run(): Promise<void>;
+}
+
+export interface CommandStatics {
+  summary(): string;
+  syntax(): string;
+  options(): CommandDetail[];
+  seeAlso(): CommandDetail[] | void;
+}
+
+export type CommandClass = (new (argv: string[]) => Command) & CommandStatics;
+
+export type CommandDetail = {
+  name: string,
+  summary: string
+};
+
+export enum CommandName {
+  Help = 'help',
+  Dist = 'dist',
+  CrossDist = 'cross-dist',
+  CrossPack = 'cross-pack',
+  CrossInstall = 'cross-install'
+};
+
+export function isCommandName(s: string): s is CommandName {
+  const keys: string[] = Object.values(CommandName);
+  return keys.includes(s);
+}
+
+export function asCommandName(name: string): CommandName {
+  if (!isCommandName(name)) {
+    throw new RangeError(`Unrecognized command: ${name}`);
+  }
+  return name;
+}
+
+const COMMANDS: Record<CommandName, CommandClass> = {
+  [CommandName.Help]: Help,
+  [CommandName.Dist]: Dist,
+  [CommandName.CrossDist]: CrossDist,
+  [CommandName.CrossPack]: CrossPack,
+  [CommandName.CrossInstall]: CrossInstall
+};
+
+export function commandFor(name: CommandName): CommandClass {
+  return COMMANDS[name];
+}
+
+export function summaries(): CommandDetail[] {
+  return [
+    { name: CommandName.Help, summary: Help.summary() },
+    { name: CommandName.Dist, summary: Dist.summary() },
+    { name: CommandName.CrossDist, summary: CrossDist.summary() },
+    { name: CommandName.CrossPack, summary: CrossPack.summary() },
+    { name: CommandName.CrossInstall, summary: CrossInstall.summary() }
+  ];
+}

--- a/pkgs/cli/src/commands/cross-dist.ts
+++ b/pkgs/cli/src/commands/cross-dist.ts
@@ -1,7 +1,7 @@
 import { copyFile } from 'node:fs/promises';
 import commandLineArgs from 'command-line-args';
 import { CargoMessage, CrossMessageStream, isCompilerArtifact } from '../cargo.js';
-import { Command } from '../command.js';
+import { Command, CommandDetail } from '../command.js';
 
 // FIXME: add options to infer crate name from manifests
 // --package <path/to/package.json>
@@ -29,29 +29,62 @@ async function findArtifact(
   });
 }
 
-export default function parse(argv: string[]): Command {
-  const options = commandLineArgs(OPTIONS, { argv });
-
-  if (options.log && options.file) {
-    throw new Error("Options --log and --file cannot both be enabled.");
+export default class CrossDist implements Command {
+  static summary(): string { return 'Generate a .node file from a cross-compiled prebuild'; }
+  static syntax(): string { return 'neon cross-dist [-n <name>] [-l <log>|-f <dylib>] [-d <dir>] [-o <dist>]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-n, --name', summary: 'Crate name. (Default: $npm_package_name)' },
+      { name: '-l, --log <log>', summary: 'Find dylib path from cargo messages <log>. (Default: stdin)' },
+      { name: '-d, --dir <dir>', summary: 'Crate workspace root directory. (Default: .)' },
+      {
+        name: '',
+        summary: 'This is needed to normalize paths from the log data, which cross-rs provides from within the mounted Docker filesystem, back to the host filesystem.'
+      },
+      { name: '-f, --file <dylib>', summary: 'Build .node from dylib file <dylib>.' },
+      { name: '-o, --out <dist>', summary: 'Copy output to file <dist>. (Default: index.node)' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void {
+    return [
+      { name: 'cargo messages', summary: '<https://doc.rust-lang.org/cargo/reference/external-tools.html>' },
+      { name: 'cross-rs', summary: '<https://github.com/cross-rs/cross>' }
+    ];
   }
 
-  const crateName = options.name || process.env['npm_package_name'];
+  private _file: string | null;
+  private _log: string | null;
+  private _crateName: string;
+  private _dir: string;
+  private _out: string;
 
-  if (!crateName) {
-    throw new Error("No crate name provided.");
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv });
+
+    if (options.log && options.file) {
+      throw new Error("Options --log and --file cannot both be enabled.");
+    }
+
+    this._file = options.file ?? null;
+    this._log = options.log ?? null;
+    this._crateName = options.name || process.env['npm_package_name'];
+
+    if (!this._crateName) {
+      throw new Error("No crate name provided.");
+    }
+
+    this._dir = options.dir || process.cwd();
+    this._out = options.out;
   }
 
-  const dir = options.dir || process.cwd();
-
-  return async () => {
-    const file = options.file ?? await findArtifact(options.log, crateName, dir);
+  async run() {
+    const file = this._file ?? await findArtifact(this._log, this._crateName, this._dir);
 
     if (!file) {
-      throw new Error(`No library found for crate ${crateName}`);
+      throw new Error(`No library found for crate ${this._crateName}`);
     }
 
     // FIXME: needs all the logic of cargo-cp-artifact (timestamp check, M1 workaround, async, errors)
-    await copyFile(file, options.out);
-  };
+    await copyFile(file, this._out);
+  }
 }

--- a/pkgs/cli/src/commands/cross-install.ts
+++ b/pkgs/cli/src/commands/cross-install.ts
@@ -2,25 +2,49 @@ import { execa } from 'execa';
 import commandLineArgs from 'command-line-args';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { Command } from '../command.js';
+import { Command, CommandDetail } from '../command.js';
 
 const OPTIONS = [
   { name: 'bundle', alias: 'b', type: String, defaultValue: null },
   { name: 'no-bundle', alias: 'B', type: String, defaultValue: null }
 ];
 
-export default function parse(argv: string[]): Command {
-  const options = commandLineArgs(OPTIONS, { argv });
-
-  if (options.bundle && options['no-bundle']) {
-    throw new Error("Options --bundle and --no-bundle cannot both be enabled.");
+export default class CrossInstall implements Command {
+  static summary(): string { return 'Install dependencies on cross-compiled prebuilds'; }
+  static syntax(): string { return 'neon cross-install [-b <file>|-B]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-b, --bundle <file>', summary: 'File to generate bundling metadata. (Default: .targets)' },
+      {
+        name: '',
+        summary: 'This generated file ensures support for bundlers (e.g. @vercel/ncc), which rely on static analysis to detect and enable any addons used by the library.'
+      },
+      { name: '-B, --no-bundle', summary: 'Do not generate bundling metadata.' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void {
+    return [
+      { name: 'ncc', summary: '<https://github.com/vercel/ncc>' }
+    ];
   }
 
-  if (!options.bundle && !options['no-bundle']) {
-    options.bundle = '.targets';
+  private _bundle: string | null;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv });
+
+    if (options.bundle && options['no-bundle']) {
+      throw new Error("Options --bundle and --no-bundle cannot both be enabled.");
+    }
+
+    this._bundle = options['no-bundle']
+      ? null
+      : !options.bundle
+      ? '.targets'
+      : options.bundle;
   }
 
-  return async () => {
+  async run() {
     const manifest = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package.json'), { encoding: 'utf8' }));
     const version = manifest.version;
 
@@ -33,7 +57,7 @@ export default function parse(argv: string[]): Command {
       process.exit(result.exitCode);
     }
 
-    if (!options.bundle) {
+    if (!this._bundle) {
       return;
     }
 
@@ -52,6 +76,6 @@ return;
 
     const requires = targets.map(name => `require('${name}');`).join('\n');
 
-    await fs.writeFile(options.bundle, PREAMBLE + requires + '\n');
-  };
+    await fs.writeFile(this._bundle, PREAMBLE + requires + '\n');
+  }
 }

--- a/pkgs/cli/src/commands/help.ts
+++ b/pkgs/cli/src/commands/help.ts
@@ -1,0 +1,26 @@
+import { printUsage } from '../print.js';
+import { Command, CommandName, CommandDetail, asCommandName } from '../command.js';
+
+export default class Help implements Command {
+  static summary(): string { return 'Display help information about Neon'; }
+  static syntax(): string { return 'neon help <command>'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '<command>', summary: 'Command to display help information about.' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+
+  private _name?: CommandName;
+
+  constructor(argv: string[]) {
+    this._name = argv.length > 0 ? asCommandName(argv[0]) : undefined;
+    if (argv.length > 1) {
+      throw new Error(`Unexpected argument: ${argv[1]}`);
+    }
+  }
+
+  async run() {
+    printUsage(this._name);
+  }
+}

--- a/pkgs/cli/src/print.ts
+++ b/pkgs/cli/src/print.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import commandLineUsage from 'command-line-usage';
 import chalk from 'chalk';
-import type { CommandName } from './index.js';
+import { CommandName, CommandStatics, commandFor, summaries } from './command.js';
 
 function pink(text: string): string {
   return chalk.bold.hex('#e75480')(text);
@@ -19,27 +19,25 @@ function green(text: string): string {
   return chalk.bold.greenBright(text);
 }
 
-function commandUsage(name: CommandName, command: CommandUsage): string {
+function commandUsage(name: CommandName, command: CommandStatics): string {
   const sections = [
     {
-      content: `${pink('Neon:')} ${name} - ${COMMAND_SUMMARIES[name]}`,
+      content: `${pink('Neon:')} ${name} - ${command.summary()}`,
       raw: true
     },
     {
       header: blue('Usage:'),
-      content: `${blue('$')} ${command.syntax}`
+      content: `${blue('$')} ${command.syntax()}`
     },
     {
       header: yellow('Options:'),
-      content: command.options
+      content: command.options()
     }
   ];
 
-  if (command.seeAlso) {
-    sections.push({
-      header: green('See Also:'),
-      content: command.seeAlso
-    });
+  const seeAlso = command.seeAlso();
+  if (seeAlso) {
+    sections.push({ header: green('See Also:'), content: seeAlso });
   }
 
   return commandLineUsage(sections);
@@ -60,105 +58,16 @@ function mainUsage(): string {
     },
     {
       header: yellow('Commands:'),
-      content: [
-        { name: 'help', summary: COMMAND_SUMMARIES['help'] + '.' },
-        { name: 'dist', summary: COMMAND_SUMMARIES['dist'] + '.' },
-        { name: 'cross-dist', summary: COMMAND_SUMMARIES['cross-dist'] + '.' },
-        { name: 'cross-pack', summary: COMMAND_SUMMARIES['cross-pack'] + '.' },
-        { name: 'cross-install', summary: COMMAND_SUMMARIES['cross-install'] + '.' }
-      ]
+      content: summaries()
     }
   ];
 
   return commandLineUsage(sections);
 }
 
-const COMMAND_SUMMARIES = {
-  'help': 'Display help information about Neon',
-  'dist': 'Generate a .node file from a build',
-  'cross-dist': 'Generate a .node file from a cross-compiled prebuild',
-  'cross-pack': 'Create an npm tarball from a cross-compiled prebuild',
-  'cross-install': 'Install dependencies on cross-compiled prebuilds'
-};
-
-type CommandUsage = {
-  syntax: string,
-  options: any[],
-  seeAlso?: any[]
-};
-
-const COMMAND_USAGES: Record<CommandName, CommandUsage> = {
-  'help': {
-    syntax: 'neon help <command>',
-    options: [
-      { name: '<command>', summary: 'Command to display help information about.' }
-    ]
-  },
-
-  'dist': {
-    syntax: 'neon dist [-n <name>] [-l <log>|-f <dylib>] [-o <dist>]',
-    options: [
-      { name: '-n, --name', summary: 'Crate name. (Default: $npm_package_name)' },
-      { name: '-l, --log <log>', summary: 'Find dylib path from cargo messages <log>. (Default: stdin)' },
-      { name: '-f, --file <dylib>', summary: 'Build .node from dylib file <dylib>.' },
-      { name: '-o, --out <dist>', summary: 'Copy output to file <dist>. (Default: index.node)' }
-    ],
-    seeAlso: [
-      { name: 'cargo messages', summary: '<https://doc.rust-lang.org/cargo/reference/external-tools.html>' }
-    ]
-  },
-
-  'cross-dist': {
-    syntax: 'neon cross-dist [-n <name>] [-l <log>|-f <dylib>] [-d <dir>] [-o <dist>]',
-    options: [
-      { name: '-n, --name', summary: 'Crate name. (Default: $npm_package_name)' },
-      { name: '-l, --log <log>', summary: 'Find dylib path from cargo messages <log>. (Default: stdin)' },
-      { name: '-d, --dir <dir>', summary: 'Crate workspace root directory. (Default: .)' },
-      {
-        name: '',
-        summary: 'This is needed to normalize paths from the log data, which cross-rs provides from within the mounted Docker filesystem, back to the host filesystem.'
-      },
-      { name: '-f, --file <dylib>', summary: 'Build .node from dylib file <dylib>.' },
-      { name: '-o, --out <dist>', summary: 'Copy output to file <dist>. (Default: index.node)' }
-    ],
-    seeAlso: [
-      { name: 'cargo messages', summary: '<https://doc.rust-lang.org/cargo/reference/external-tools.html>' },
-      { name: 'cross-rs', summary: '<https://github.com/cross-rs/cross>' }
-    ]
-  },
-
-  'cross-pack': {
-    syntax: 'neon cross-pack [-f <addon>] <target>',
-    options: [
-      { name: '-f, --file <addon>', summary: 'Prebuilt .node file to pack. (Default: index.node)' },
-      { name: '<target>', summary: 'Rust target triple the addon was built for.' }
-    ],
-    seeAlso: [
-      { name: 'Rust platform support', summary: '<https://doc.rust-lang.org/rustc/platform-support.html>' },
-      { name: 'npm pack', summary: '<https://docs.npmjs.com/cli/commands/npm-pack>' },
-      { name: 'cross-rs', summary: '<https://github.com/cross-rs/cross>' }
-    ]
-  },
-
-  'cross-install': {
-    syntax: 'neon cross-install [-b <file>|-B]',
-    options: [
-      { name: '-b, --bundle <file>', summary: 'File to generate bundling metadata. (Default: .targets)' },
-      {
-        name: '',
-        summary: 'This generated file ensures support for bundlers (e.g. @vercel/ncc), which rely on static analysis to detect and enable any addons used by the library.'
-      },
-      { name: '-B, --no-bundle', summary: 'Do not generate bundling metadata.' }
-    ],
-    seeAlso: [
-      { name: 'ncc', summary: '<https://github.com/vercel/ncc>' }
-    ]
-  }
-};
-
 export function printUsage(command?: CommandName) {
   if (command) {
-    console.error(commandUsage(command, COMMAND_USAGES[command]));
+    console.error(commandUsage(command, commandFor(command)));
   } else {
     console.error(mainUsage());
   }


### PR DESCRIPTION
Store usage info in class statics instead of in `print.ts`, so that usage info and command-line parsing are colocated and will be easier to keep in sync.