### PR TITLE
Cleaner commands design

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.3.4
+        uses: neon-actions/build@v0.4
         with:
           working-directory: ./pkgs/cargo-messages
           target: linux-x64-gnu

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.3.4
+        uses: neon-actions/build@v0.4
         with:
           working-directory: ./pkgs/cargo-messages
           target: ${{ matrix.target }}
@@ -99,7 +99,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.3.4
+        uses: neon-actions/build@v0.4
         with:
           working-directory: ./pkgs/cargo-messages
           target: ${{ matrix.target }}
@@ -136,7 +136,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.3.4
+        uses: neon-actions/build@v0.4
         with:
           working-directory: ./pkgs/cargo-messages
           target: ${{ matrix.target }}

--- a/src/cli/src/command.ts
+++ b/src/cli/src/command.ts
@@ -1,7 +1,8 @@
 import Dist from './commands/dist.js';
 import Bump from './commands/bump.js';
-import PackBuild from './commands/pack-build.js';
-import InstallBuilds from './commands/install-builds.js';
+import Tarball from './commands/tarball.js';
+import AddTarget from './commands/add-target.js';
+import UpdateTargets from './commands/update-targets.js';
 import Help from './commands/help.js';
 
 export interface Command {
@@ -26,8 +27,11 @@ export enum CommandName {
   Help = 'help',
   Dist = 'dist',
   Bump = 'bump',
-  PackBuild = 'pack-build',
-  InstallBuilds = 'install-builds'
+  PackBuild = 'pack-build', // deprecated but retained for compat
+  Tarball = 'tarball',
+  AddTarget = 'add-target',
+  InstallBuilds = 'install-builds', // deprecated but retained for compat
+  UpdateTargets = 'update-targets'
 };
 
 export function isCommandName(s: string): s is CommandName {
@@ -46,8 +50,11 @@ const COMMANDS: Record<CommandName, CommandClass> = {
   [CommandName.Help]: Help,
   [CommandName.Dist]: Dist,
   [CommandName.Bump]: Bump,
-  [CommandName.PackBuild]: PackBuild,
-  [CommandName.InstallBuilds]: InstallBuilds
+  [CommandName.PackBuild]: Tarball, // deprecated but retained for compat
+  [CommandName.Tarball]: Tarball,
+  [CommandName.AddTarget]: AddTarget,
+  [CommandName.InstallBuilds]: UpdateTargets, // deprecated but retained for compat
+  [CommandName.UpdateTargets]: UpdateTargets
 };
 
 export function commandFor(name: CommandName): CommandClass {
@@ -59,7 +66,8 @@ export function summaries(): CommandDetail[] {
     { name: CommandName.Help, summary: Help.summary() },
     { name: CommandName.Dist, summary: Dist.summary() },
     { name: CommandName.Bump, summary: Bump.summary() },
-    { name: CommandName.PackBuild, summary: PackBuild.summary() },
-    { name: CommandName.InstallBuilds, summary: InstallBuilds.summary() }
+    { name: CommandName.Tarball, summary: Tarball.summary() },
+    { name: CommandName.AddTarget, summary: AddTarget.summary() },
+    { name: CommandName.UpdateTargets, summary: UpdateTargets.summary() }
   ];
 }

--- a/src/cli/src/commands/add-target.ts
+++ b/src/cli/src/commands/add-target.ts
@@ -1,0 +1,105 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail } from '../command.js';
+import { getCurrentTarget, isNodeTarget, isRustTarget } from '../target.js';
+import { SourceManifest } from '../manifest.js';
+
+const OPTIONS = [
+  { name: 'bundle', alias: 'b', type: String, defaultValue: null },
+  { name: 'platform', alias: 'p', type: String, defaultValue: null },
+  { name: 'arch', alias: 'a', type: String, defaultValue: null },
+  { name: 'abi', type: String, defaultValue: null },
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class AddTarget implements Command {
+    static summary(): string { return 'Add a new build target to package.json.'; }
+    static syntax(): string { return 'neon add-target [<target> | -p <plat> -a <arch> [--abi <abi>]] [-b <file>]'; }
+    static options(): CommandDetail[] {
+      return [
+        { name: '<target>', summary: 'Full target name, in either Node or Rust convention. (Default: current target)' },
+        { name: '-p, --platform <plat>', summary: 'Target platform name. (Default: current platform)' },
+        { name: '-a, --arch <arch>', summary: 'Target architecture name. (Default: current arch)' },
+        { name: '--abi <abi>', summary: 'Target ABI name. (Default: current ABI)' },
+        { name: '-b, --bundle <file>', summary: 'File to generate bundling metadata.' },
+        {
+          name: '',
+          summary: 'This generated file ensures support for bundlers (e.g. @vercel/ncc), which rely on static analysis to detect and enable any addons used by the library.'
+        },
+        { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+    ];
+    }
+    static seeAlso(): CommandDetail[] | void {
+      return [
+      ];
+    }
+  
+    private _platform: string | null;
+    private _arch: string | null;
+    private _abi: string | null;
+    private _target: string | null;
+    private _bundle: string | null;
+    private _verbose: boolean;
+  
+    constructor(argv: string[]) {
+      const options = commandLineArgs(OPTIONS, { argv, partial: true });
+  
+      this._platform = options.platform || null;
+      this._arch = options.arch || null;
+      this._abi = options.abi || null;
+      this._bundle = options.bundle || null;
+      this._verbose = !!options.verbose;
+
+      if (options.platform && !options.arch) {
+        throw new Error("Option --platform requires option --arch to be specified as well.");
+      }
+
+      if (!options.platform && options.arch) {
+        throw new Error("Option --arch requires option --platform to be specified as well.");
+      }
+
+      if (options.abi && (!options.platform || !options.arch)) {
+        throw new Error("Option --abi requires both options --platform and --arch to be specified as well.");
+      }
+
+      if (!options.platform && !options.arch && !options.abi) {
+        if (!options._unknown || options._unknown.length === 0) {
+          throw new Error("No arguments found, expected <target> or -p and -a options.");
+        }
+        this._target = options._unknown[0];
+      } else {
+        this._target = null;
+      }
+    }
+
+    log(msg: string) {
+      if (this._verbose) {
+        console.error("[neon add-target] " + msg);
+      }
+    }
+  
+    async addTarget(sourceManifest: SourceManifest): Promise<boolean> {
+      if (!this._target) {
+        this.log('adding default system target');
+        return sourceManifest.addRustTarget(await getCurrentTarget(msg => this.log(msg)));
+      } else if (isRustTarget(this._target)) {
+        this.log(`adding Rust target ${this._target}`);
+        return sourceManifest.addRustTarget(this._target);
+      } else if (isNodeTarget(this._target)) {
+        this.log(`adding Node target ${this._target}`);
+        return sourceManifest.addNodeTarget(this._target);
+      } else {
+        throw new Error(`unrecognized target ${this._target}`);
+      }
+    }
+
+    async run() {
+      this.log(`reading package.json`);
+      const sourceManifest = await SourceManifest.load();
+      this.log(`manifest: ${sourceManifest.stringify()}`);
+
+      if (await this.addTarget(sourceManifest)) {
+        sourceManifest.updateTargets(msg => this.log(msg), this._bundle);
+      }
+    }
+  }
+  

--- a/src/cli/src/commands/dist.ts
+++ b/src/cli/src/commands/dist.ts
@@ -22,7 +22,7 @@ function createInputStream(file: string | null): NodeJS.ReadableStream {
 }
 
 export default class Dist implements Command {
-  static summary(): string { return 'Generate a .node file from a build.'; }
+  static summary(): string { return 'Generate a binary .node file from a cargo output log.'; }
   static syntax(): string { return 'neon dist [-n <name>] [-f <dylib>|[-l <log>] [-m <path>]] [-o <dist>]'; }
   static options(): CommandDetail[] {
     return [

--- a/test/integration/proxy/publish.sh
+++ b/test/integration/proxy/publish.sh
@@ -17,6 +17,6 @@ cd test/integration/sniff-bytes
 npm i
 npm run build
 mkdir -p dist
-PACKAGE_TARBALL=$(npm run pack-build -- --out-dir dist | tail -1)
+PACKAGE_TARBALL=$(npx neon tarball --out-dir dist | tail -1)
 npm publish ./${PACKAGE_TARBALL} --registry $PROXY_SERVER
 npm publish --registry $PROXY_SERVER

--- a/test/integration/sniff-bytes/package.json
+++ b/test/integration/sniff-bytes/package.json
@@ -30,8 +30,7 @@
     "debug": "cargo build --message-format=json | neon dist",
     "build": "cargo build --message-format=json --release | neon dist -v -n sniff-bytes",
     "cross": "cross build --message-format=json --release | neon dist -v -n sniff-bytes -m /target",
-    "pack-build": "neon pack-build -v",
-    "prepack": "neon install-builds -v"
+    "prepack": "neon update-targets -v"
   },
   "license": "MIT",
   "neon": {


### PR DESCRIPTION
Summary

- `neon pack-build` --> `neon tarball` (more self-evident what it creates)
- `neon install-builds` --> `neon update-targets` (more consistent with npm naming conventions)
- `neon add-target`: new command that adds a target to package.json
- retain the old command names for backwards compatibility but don't show them in `help`

<img width="633" alt="image" src="https://github.com/dherman/neon-rs/assets/307871/9a0251f5-524b-4cdd-a37d-e0d1e934a6c8">
