### PR TITLE
Allow presets in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # `@neon-rs`
 
 Experimental packaging and distribution tooling for [Neon](https://neon-bindings.com).
+
+# Build Workflow of a Neon Project
+
+```
+( Start ) ---- npm run build ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+ \ \ \ \ \
+  \ \ \ \ +--- npm run cross ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+   \ \ \ \
+    \ \ \ +--- npm run cross ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+     \ \ \
+      \ \ +--- npm run cross ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+       \ \
+        \ +--- npm run cross ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+         \
+          +--- npm run cross ----> ( .node ) ---- npm run pack-target ----> ( .tgz ) ---- npm publish ----> [ npm ]
+```

--- a/src/cli/src/commands/add-target.ts
+++ b/src/cli/src/commands/add-target.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import commandLineArgs from 'command-line-args';
 import { Command, CommandDetail, CommandSection } from '../command.js';
-import { expandTargetFamily, getCurrentTarget, isNodeTarget, isRustTarget, isTargetFamilyKey, NodeTarget, RustTarget, TargetPair } from '../target.js';
+import { getCurrentTarget, isNodeTarget, isRustTarget, isTargetPreset, TargetPair } from '../target.js';
 import { SourceManifest } from '../manifest.js';
 
 function optionArray<T>(option: T | undefined | null): T[] {
@@ -116,8 +116,8 @@ export default class AddTarget implements Command {
       } else if (isNodeTarget(this._target)) {
         this.log(`adding Node target ${this._target}`);
         return optionArray(await sourceManifest.addNodeTarget(this._target));
-      } else if (isTargetFamilyKey(this._target)) {
-        return sourceManifest.addTargets(expandTargetFamily(this._target));
+      } else if (isTargetPreset(this._target)) {
+        return sourceManifest.addTargetPreset(this._target);
       } else {
         throw new Error(`unrecognized target ${this._target}`);
       }

--- a/src/cli/src/commands/rust-target.ts
+++ b/src/cli/src/commands/rust-target.ts
@@ -84,8 +84,7 @@ export default class RustTarget implements Command {
     const sourceManifest = await SourceManifest.load();
     this.log(`manifest: ${sourceManifest.stringify()}`);
 
-    const targets = sourceManifest.cfg().targets;
-    const rust = targets[this._target];
+    const rust = sourceManifest.rustTargetFor(this._target);
     if (!rust) {
       throw new Error(`no Rust target found for ${this._target}`);
     }

--- a/src/cli/src/target.ts
+++ b/src/cli/src/target.ts
@@ -28,15 +28,15 @@ export function assertIsNodeTarget(x: unknown): asserts x is NodeTarget {
   }
 }
 
-export type TargetFamilyKey = keyof(typeof FAMILY);
+export type TargetPreset = keyof(typeof FAMILY);
 
-export function isTargetFamilyKey(x: unknown): x is TargetFamilyKey {
+export function isTargetPreset(x: unknown): x is TargetPreset {
   return (typeof x === 'string') && (x in FAMILY);
 }
 
-export function assertIsTargetFamilyKey(x: unknown): asserts x is TargetFamilyKey {
-  if (!isTargetFamilyKey(x)) {
-    throw new RangeError(`invalid target family name: ${x}`);
+export function assertIsTargetPreset(x: unknown): asserts x is TargetPreset {
+  if (!isTargetPreset(x)) {
+    throw new RangeError(`invalid target family preset: ${x}`);
   }
 }
 
@@ -44,11 +44,11 @@ export type TargetPair = { node: NodeTarget, rust: RustTarget };
 export type TargetMap = { [key in NodeTarget]?: RustTarget };
 
 export type TargetFamily =
-    TargetFamilyKey
-  | TargetFamilyKey[]
+    TargetPreset
+  | TargetPreset[]
   | TargetMap;
 
-function lookupTargetFamily(key: TargetFamilyKey): TargetFamily {
+function lookupTargetFamily(key: TargetPreset): TargetFamily {
   return FAMILY[key] as TargetFamily;
 }
 
@@ -61,7 +61,7 @@ function merge(maps: TargetMap[]): TargetMap {
 }
 
 export function expandTargetFamily(family: TargetFamily): TargetMap {
-  return isTargetFamilyKey(family)
+  return isTargetPreset(family)
     ? expandTargetFamily(lookupTargetFamily(family))
     : Array.isArray(family)
     ? merge(family.map(expandTargetFamily))

--- a/test/integration/sniff-bytes/npm/darwin-arm64/README.md
+++ b/test/integration/sniff-bytes/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `@sniff-bytes/darwin-arm64`
+
+Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `darwin-arm64`.

--- a/test/integration/sniff-bytes/npm/darwin-arm64/package.json
+++ b/test/integration/sniff-bytes/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sniff-bytes/darwin-arm64",
-  "description": "Prebuilt binary package for `sniff-bytes` on `darwin-arm64`.",
-  "version": "0.1.11",
+  "description": "Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `darwin-arm64`.",
+  "version": "1.0.0",
   "os": [
     "darwin"
   ],
@@ -12,7 +12,6 @@
   "files": [
     "index.node"
   ],
-  "license": "MIT",
   "neon": {
     "type": "binary",
     "rust": "aarch64-apple-darwin",
@@ -20,5 +19,6 @@
     "platform": "darwin",
     "arch": "arm64",
     "abi": null
-  }
+  },
+  "license": "MIT"
 }

--- a/test/integration/sniff-bytes/npm/darwin-x64/README.md
+++ b/test/integration/sniff-bytes/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `@sniff-bytes/darwin-x64`
+
+Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `darwin-x64`.

--- a/test/integration/sniff-bytes/npm/darwin-x64/package.json
+++ b/test/integration/sniff-bytes/npm/darwin-x64/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sniff-bytes/darwin-x64",
+  "description": "Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `darwin-x64`.",
+  "version": "1.0.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "neon": {
+    "type": "binary",
+    "rust": "x86_64-apple-darwin",
+    "node": "darwin-x64",
+    "platform": "darwin",
+    "arch": "x64",
+    "abi": null
+  },
+  "license": "MIT"
+}

--- a/test/integration/sniff-bytes/npm/linux-arm-gnueabihf/README.md
+++ b/test/integration/sniff-bytes/npm/linux-arm-gnueabihf/README.md
@@ -1,0 +1,3 @@
+# `@sniff-bytes/linux-arm-gnueabihf`
+
+Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-arm-gnueabihf`.

--- a/test/integration/sniff-bytes/npm/linux-arm-gnueabihf/package.json
+++ b/test/integration/sniff-bytes/npm/linux-arm-gnueabihf/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sniff-bytes/linux-arm-gnueabihf",
+  "description": "Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-arm-gnueabihf`.",
+  "version": "1.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm"
+  ],
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "neon": {
+    "type": "binary",
+    "rust": "armv7-unknown-linux-gnueabihf",
+    "node": "linux-arm-gnueabihf",
+    "platform": "linux",
+    "arch": "arm",
+    "abi": "gnueabihf"
+  },
+  "license": "MIT"
+}

--- a/test/integration/sniff-bytes/npm/linux-x64-gnu/README.md
+++ b/test/integration/sniff-bytes/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@sniff-bytes/linux-x64-gnu`
+
+Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-x64-gnu`.

--- a/test/integration/sniff-bytes/npm/linux-x64-gnu/package.json
+++ b/test/integration/sniff-bytes/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sniff-bytes/linux-x64-gnu",
-  "description": "Prebuilt binary package for `sniff-bytes` on `linux-x64-gnu`.",
-  "version": "1.0",
+  "description": "Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-x64-gnu`.",
+  "version": "1.0.0",
   "os": [
     "linux"
   ],
@@ -12,7 +12,6 @@
   "files": [
     "index.node"
   ],
-  "license": "MIT",
   "neon": {
     "type": "binary",
     "rust": "x86_64-unknown-linux-gnu",
@@ -20,5 +19,6 @@
     "platform": "linux",
     "arch": "x64",
     "abi": "gnu"
-  }
+  },
+  "license": "MIT"
 }

--- a/test/integration/sniff-bytes/package.json
+++ b/test/integration/sniff-bytes/package.json
@@ -36,10 +36,10 @@
   "neon": {
     "type": "source",
     "org": "@sniff-bytes",
-    "targets": {
-      "linux-x64-gnu": "x86_64-unknown-linux-gnu",
-      "darwin-arm64": "aarch64-apple-darwin"
-    }
+    "targets": [
+      "linux",
+      "macos"
+    ]
   },
   "devDependencies": {
     "@neon-rs/cli": "*",
@@ -51,6 +51,8 @@
   },
   "optionalDependencies": {
     "@sniff-bytes/darwin-arm64": "1.0.0",
+    "@sniff-bytes/darwin-x64": "1.0.0",
+    "@sniff-bytes/linux-arm-gnueabihf": "1.0.0",
     "@sniff-bytes/linux-x64-gnu": "1.0.0"
   }
 }


### PR DESCRIPTION
Allow target family presets in `package.json` (under `neon.targets`):

- `neon rust-target` recognizes presets in the manifest and knows how to expand them based on the FAMILY.json database
- `neon add-target` no longer automatically expands the preset in the manifest, allowing for more readable manifests
- integration test `sniff-bytes` uses presets in the manifest for testing