### PR TITLE
Use `extended` preset for `cargo-messages`

### DIFF
--- a/pkgs/cargo-messages/package.json
+++ b/pkgs/cargo-messages/package.json
@@ -37,7 +37,7 @@
   "author": "David Herman <david.herman@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@neon-rs/cli": "^0.0.167"
+    "@neon-rs/cli": "^0.0.168"
   },
   "repository": {
     "type": "git",
@@ -57,15 +57,7 @@
   "neon": {
     "type": "source",
     "org": "@cargo-messages",
-    "targets": {
-      "win32-x64-msvc": "x86_64-pc-windows-msvc",
-      "win32-arm64-msvc": "aarch64-pc-windows-msvc",
-      "darwin-x64": "x86_64-apple-darwin",
-      "darwin-arm64": "aarch64-apple-darwin",
-      "linux-x64-gnu": "x86_64-unknown-linux-gnu",
-      "linux-arm-gnueabihf": "armv7-unknown-linux-gnueabihf",
-      "android-arm-eabi": "armv7-linux-androideabi"
-    }
+    "targets": "extended"
   },
   "optionalDependencies": {
     "@cargo-messages/android-arm-eabi": "0.0.168",

--- a/pkgs/package-lock.json
+++ b/pkgs/package-lock.json
@@ -14,24 +14,17 @@
         "cargo-messages"
       ],
       "devDependencies": {
-        "@neon-rs/cli": "^0.0.167"
+        "@neon-rs/cli": "^0.0.168"
       }
     },
     "cargo-messages": {
       "version": "0.0.168",
       "license": "MIT",
       "dependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.168",
-        "@cargo-messages/darwin-arm64": "0.0.168",
-        "@cargo-messages/darwin-x64": "0.0.168",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.168",
-        "@cargo-messages/linux-x64-gnu": "0.0.168",
-        "@cargo-messages/win32-arm64-msvc": "0.0.168",
-        "@cargo-messages/win32-x64-msvc": "0.0.168",
         "@neon-rs/load": "^0.0.158"
       },
       "devDependencies": {
-        "@neon-rs/cli": "^0.0.167"
+        "@neon-rs/cli": "^0.0.168"
       },
       "optionalDependencies": {
         "@cargo-messages/android-arm-eabi": "0.0.168",
@@ -43,108 +36,6 @@
         "@cargo-messages/win32-x64-msvc": "0.0.168"
       }
     },
-    "cargo-messages/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.168.tgz",
-      "integrity": "sha512-tXOX6a7Xxe5yrqS+V7FC3HqIsi9yzvHvnpreFZUt/PLpfQ7lRM40jeUlmB/6L94q+zuvmpCg/+VQWnLNxyRzig==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.168.tgz",
-      "integrity": "sha512-KYgP9i1JIT6tGPgoUbG1rHDsAd3eUO8qWegX3qSutKPGnINMV/cu7LBnZz3BgLrjhsVDhQAOMN2CIDJ4l5OCAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.168.tgz",
-      "integrity": "sha512-b/YsLHxK8KtMUIozTYE8y77SYNxaO8E1yUFKoeAJ1sMf70Sdv2aSQ6NP6l1J4TCsULqKOJg+MZMZp5jz3D94rA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.168.tgz",
-      "integrity": "sha512-Iw6flzL1uChO4GyCh7amKreOU67kzk4GkOKaQzBZUgsrm+5kM+rBpGmETL5I4DLKtLhpehw31BG8v5Ac98QP9A==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.168.tgz",
-      "integrity": "sha512-2atl00JD1vNlD7lCJe9znx5OZ+vzPrJn10BQjXtUcKj/ZaTBwXqr7lRomauLgMNAD3e/lk1UBvsEPwNhvmjH7A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.168.tgz",
-      "integrity": "sha512-+PUFD+sbmoZVfvqNgE3dXAB9uA34ZGjedC7mfq3E1S0Ab33+gbB3WI4PuL5cz6cPAw7iX5jn/F2z/XRpv50miQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.168.tgz",
-      "integrity": "sha512-J+7LLQnaE8/D2wYwoFDsK7vqXi8RYUYHsQ7uzX3g+BXN3H9k7Mi9EL5wiXDDtgyWRaarx1MFFrfO2r2PfD+nxg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cargo-messages/node_modules/@neon-rs/cli": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.0.167.tgz",
-      "integrity": "sha512-bjku39NYQsCCF2Ia3vRpaD1Oqwx1gq4aSdDRKu+2EO6q7mN1kJ/sNlVwSlTWYK1qj1xvzXonBdB8obeEbvTLVA==",
-      "dev": true,
-      "bin": {
-        "neon": "index.js"
-      },
-      "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.167",
-        "@cargo-messages/darwin-arm64": "0.0.167",
-        "@cargo-messages/darwin-x64": "0.0.167",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.167",
-        "@cargo-messages/linux-x64-gnu": "0.0.167",
-        "@cargo-messages/win32-arm64-msvc": "0.0.167",
-        "@cargo-messages/win32-x64-msvc": "0.0.167"
-      }
-    },
     "cargo-messages/node_modules/@neon-rs/cli/node_modules/@cargo-messages/android-arm-eabi": {
       "version": "0.0.167",
       "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.167.tgz",
@@ -152,8 +43,7 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "android"
       ]
@@ -165,8 +55,7 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "darwin"
       ]
@@ -178,8 +67,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "darwin"
       ]
@@ -191,8 +79,7 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "linux"
       ]
@@ -204,8 +91,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "linux"
       ]
@@ -217,8 +103,7 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "win32"
       ]
@@ -230,8 +115,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "win32"
       ]
@@ -249,13 +133,13 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.167",
-        "@cargo-messages/darwin-arm64": "0.0.167",
-        "@cargo-messages/darwin-x64": "0.0.167",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.167",
-        "@cargo-messages/linux-x64-gnu": "0.0.167",
-        "@cargo-messages/win32-arm64-msvc": "0.0.167",
-        "@cargo-messages/win32-x64-msvc": "0.0.167"
+        "@cargo-messages/android-arm-eabi": "0.0.168",
+        "@cargo-messages/darwin-arm64": "0.0.168",
+        "@cargo-messages/darwin-x64": "0.0.168",
+        "@cargo-messages/linux-arm-gnueabihf": "0.0.168",
+        "@cargo-messages/linux-x64-gnu": "0.0.168",
+        "@cargo-messages/win32-arm64-msvc": "0.0.168",
+        "@cargo-messages/win32-x64-msvc": "0.0.168"
       }
     },
     "install": {
@@ -272,9 +156,9 @@
       }
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.167.tgz",
-      "integrity": "sha512-y003pQdJh+geDrVEqS3he1E1X1D6fbwwGagDZvZE7lHWJ7xgvx1vHOM2E21b/BW8bYekSTZlENEU4FdKfczo8w==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.168.tgz",
+      "integrity": "sha512-tXOX6a7Xxe5yrqS+V7FC3HqIsi9yzvHvnpreFZUt/PLpfQ7lRM40jeUlmB/6L94q+zuvmpCg/+VQWnLNxyRzig==",
       "cpu": [
         "arm"
       ],
@@ -284,9 +168,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.167.tgz",
-      "integrity": "sha512-55G2geAF2XRt8CybYzk66Qkf6oxJ240lEt3LBsqg2wEoRnxXA0eyVxsnRjgAgzowXoOQjg4Zc+ETufh9gbokwA==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.168.tgz",
+      "integrity": "sha512-KYgP9i1JIT6tGPgoUbG1rHDsAd3eUO8qWegX3qSutKPGnINMV/cu7LBnZz3BgLrjhsVDhQAOMN2CIDJ4l5OCAQ==",
       "cpu": [
         "arm64"
       ],
@@ -296,9 +180,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.167.tgz",
-      "integrity": "sha512-azvD6ZqfWn5nzJp7HGIGI0+2SViRLYb1fybfBwjA9/He/1vLhkKgH/MFMjUAtypNKaRc086rgBG73uHkrNAT7A==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.168.tgz",
+      "integrity": "sha512-b/YsLHxK8KtMUIozTYE8y77SYNxaO8E1yUFKoeAJ1sMf70Sdv2aSQ6NP6l1J4TCsULqKOJg+MZMZp5jz3D94rA==",
       "cpu": [
         "x64"
       ],
@@ -308,9 +192,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.167.tgz",
-      "integrity": "sha512-kkMUnuE/Ie/MGSkNzLhEJOai+ilrHKj7GPSvT4X8kLAri5FaP6pCP+A3OGAn5QghpWv6CD4zYtF7FirfrHqJjQ==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.168.tgz",
+      "integrity": "sha512-Iw6flzL1uChO4GyCh7amKreOU67kzk4GkOKaQzBZUgsrm+5kM+rBpGmETL5I4DLKtLhpehw31BG8v5Ac98QP9A==",
       "cpu": [
         "arm"
       ],
@@ -320,9 +204,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.167.tgz",
-      "integrity": "sha512-kPujYK2TKFGUXEPDrOW/U59BaW7ePivmV8InUBhhjsPIz2rF07AoHqldiIdqXdQCE7T4LgkT4TSpxJVZUTKrCQ==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.168.tgz",
+      "integrity": "sha512-2atl00JD1vNlD7lCJe9znx5OZ+vzPrJn10BQjXtUcKj/ZaTBwXqr7lRomauLgMNAD3e/lk1UBvsEPwNhvmjH7A==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +216,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.167.tgz",
-      "integrity": "sha512-ubOVVzSHOjtfjZz4gyYKpXLQsD2lrKQHhynYSHssqbA5jowpiNv2WlZCgwDRS9oxeDlpAanqrn2AxJl8+VIGeQ==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.168.tgz",
+      "integrity": "sha512-+PUFD+sbmoZVfvqNgE3dXAB9uA34ZGjedC7mfq3E1S0Ab33+gbB3WI4PuL5cz6cPAw7iX5jn/F2z/XRpv50miQ==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +228,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.167",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.167.tgz",
-      "integrity": "sha512-pLv7M2J3FiJf6jcZQBkUnCzBF5e/rkQSQuUywuKgS4s1LMbnMEr/StvSKc+pj47ZT+/YuQO/J1ZzNeHMgRTUVw==",
+      "version": "0.0.168",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.168.tgz",
+      "integrity": "sha512-J+7LLQnaE8/D2wYwoFDsK7vqXi8RYUYHsQ7uzX3g+BXN3H9k7Mi9EL5wiXDDtgyWRaarx1MFFrfO2r2PfD+nxg==",
       "cpu": [
         "x64"
       ],

--- a/pkgs/package.json
+++ b/pkgs/package.json
@@ -13,6 +13,6 @@
     "version": "neon bump -v --workspaces"
   },
   "devDependencies": {
-    "@neon-rs/cli": "^0.0.167"
+    "@neon-rs/cli": "^0.0.168"
   }
 }


### PR DESCRIPTION
Use the `"extended"` preset for `neon.target` configuration in `cargo-messages`'s manifest. Requires bumping to the latest CLI version.