### PR TITLE
Alternative `@neon-rs/load` APIs

### DIFF
--- a/pkgs/cargo-messages/lib/load.cjs
+++ b/pkgs/cargo-messages/lib/load.cjs
@@ -1,3 +1,14 @@
+// module.exports = require('@neon-rs/load').__UNSTABLE_proxy({
+//   'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+//   'win32-x64-msvc': () => require('@cargo-messages/win32-x64-msvc'),
+//   'aarch64-pc-windows-msvc': () => require('@cargo-messages/win32-arm64-msvc'),
+//   'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+//   'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
+//   'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
+//   'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
+//   'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
+// });
+
 module.exports = require('@neon-rs/load').lazy({
   targets: {
     'darwin-x64': () => require('@cargo-messages/darwin-x64'),


### PR DESCRIPTION
This PR experiments with a couple new alternative APIs for `@neon-rs/load`:

- `loader()`: returns a thunk, which means users don't need to specify the exports but have to remember to lazily apply the thunk to guarantee laziness
- `proxy()`: returns a proxy, which means users don't need to specify the exports and always get the correct lazy behavior no matter what

For now, these are hidden behind ugly `__UNSTABLE_foo` names.