### PR TITLE
Use experimental proxy loader for `cargo-messages`

### DIFF
--- a/pkgs/cargo-messages/lib/load.cjs
+++ b/pkgs/cargo-messages/lib/load.cjs
@@ -1,33 +1,33 @@
-// module.exports = require('@neon-rs/load').__UNSTABLE_proxy({
-//   'darwin-x64': () => require('@cargo-messages/darwin-x64'),
-//   'win32-x64-msvc': () => require('@cargo-messages/win32-x64-msvc'),
-//   'aarch64-pc-windows-msvc': () => require('@cargo-messages/win32-arm64-msvc'),
-//   'darwin-x64': () => require('@cargo-messages/darwin-x64'),
-//   'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
-//   'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
-//   'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
-//   'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
-// });
-
-module.exports = require('@neon-rs/load').lazy({
-  targets: {
-    'darwin-x64': () => require('@cargo-messages/darwin-x64'),
-    'win32-x64-msvc': () => require('@cargo-messages/win32-x64-msvc'),
-    'aarch64-pc-windows-msvc': () => require('@cargo-messages/win32-arm64-msvc'),
-    'darwin-x64': () => require('@cargo-messages/darwin-x64'),
-    'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
-    'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
-    'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
-    'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
-  },
-  exports: [
-    'findArtifact',
-    'findFileByCrateType',
-    'fromStdin',
-    'fromFile',
-    'createReader',
-    'compilerArtifactCrateName',
-    'compilerArtifactFindFileByCrateType',
-    'readline'
-  ]
+module.exports = require('@neon-rs/load').__UNSTABLE_proxy({
+  'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+  'win32-x64-msvc': () => require('@cargo-messages/win32-x64-msvc'),
+  'aarch64-pc-windows-msvc': () => require('@cargo-messages/win32-arm64-msvc'),
+  'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+  'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
+  'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
+  'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
+  'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
 });
+
+// module.exports = require('@neon-rs/load').lazy({
+//   targets: {
+//     'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+//     'win32-x64-msvc': () => require('@cargo-messages/win32-x64-msvc'),
+//     'aarch64-pc-windows-msvc': () => require('@cargo-messages/win32-arm64-msvc'),
+//     'darwin-x64': () => require('@cargo-messages/darwin-x64'),
+//     'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
+//     'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
+//     'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
+//     'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
+//   },
+//   exports: [
+//     'findArtifact',
+//     'findFileByCrateType',
+//     'fromStdin',
+//     'fromFile',
+//     'createReader',
+//     'compilerArtifactCrateName',
+//     'compilerArtifactFindFileByCrateType',
+//     'readline'
+//   ]
+// });

--- a/pkgs/cargo-messages/package.json
+++ b/pkgs/cargo-messages/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/dherman/neon-rs#readme",
   "dependencies": {
-    "@neon-rs/load": "^0.0.158"
+    "@neon-rs/load": "^0.0.169"
   },
   "neon": {
     "type": "source",

--- a/pkgs/package-lock.json
+++ b/pkgs/package-lock.json
@@ -21,14 +21,7 @@
       "version": "0.0.169",
       "license": "MIT",
       "dependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.169",
-        "@cargo-messages/darwin-arm64": "0.0.169",
-        "@cargo-messages/darwin-x64": "0.0.169",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.169",
-        "@cargo-messages/linux-x64-gnu": "0.0.169",
-        "@cargo-messages/win32-arm64-msvc": "0.0.169",
-        "@cargo-messages/win32-x64-msvc": "0.0.169",
-        "@neon-rs/load": "^0.0.158"
+        "@neon-rs/load": "^0.0.169"
       },
       "devDependencies": {
         "@neon-rs/cli": "^0.0.168"
@@ -42,90 +35,6 @@
         "@cargo-messages/win32-arm64-msvc": "0.0.169",
         "@cargo-messages/win32-x64-msvc": "0.0.169"
       }
-    },
-    "cargo-messages/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.169.tgz",
-      "integrity": "sha512-xrsotgaqqJxfw4sz2C5BJGYeRPhZ9KvI6aZkNjBToysWpxN2ScPWGOh/qiAlY/5mw8NUK0YBsKvn7VVI0ADD3A==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.169.tgz",
-      "integrity": "sha512-qmXFqPve4Uaz2iIM2sPG9+r5l2rPgAc+G5+ATDdxs4Pel4jCMDTpdrs+MjAzP4kNy0REw8jw55gCXPXz8O2u1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.169.tgz",
-      "integrity": "sha512-9KsOiOKagS6zdpyTU1TGMX/3a4AfpVXmIG0ym8WsCsUT5DMRVjK0xbW4Lo5gV2QwEVWCDGLuOWZKE4P4BOm8DQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.169.tgz",
-      "integrity": "sha512-JVotUXxyI/57MIyTVRC78r2F2USUKnqm55i//6VfskOwo0yGEm04Mh/+wRFaYZvt/eaeNymwuphBLCvvUzUpEQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.169.tgz",
-      "integrity": "sha512-y9qB2HrlTqfFFNdVdcpIvpCzvGDWEPw/6XnSwJcYKkDZx1dx0nzPckW+oqI0SsapgFO1aootWZmvb1QCFiPPLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.169.tgz",
-      "integrity": "sha512-fOhgXuzyS4cOVvE1WzEYPoAMcZPuWK0qURjFTTMNgfkt7mspSU58nrEbuzcKzJWhNs4JxVKIDFq+4o2BIeofsw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.169",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.169.tgz",
-      "integrity": "sha512-wr4Hc+fmvHFwbGmW0OE9rqknL+Ib7/LlqyPhq0Zz0wDEjnxKDSomV4NAmhg/636DK1sNMW+ppkR41lYzGg0jUg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "cargo-messages/node_modules/@neon-rs/cli": {
       "version": "0.0.168",
@@ -236,11 +145,6 @@
         "win32"
       ]
     },
-    "cargo-messages/node_modules/@neon-rs/load": {
-      "version": "0.0.158",
-      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.158.tgz",
-      "integrity": "sha512-zRkipoCMyu5eFdusb5DOcId/8zC/6xtM9+cM1E93AWAQvlEX2+PqFiltz6Fk57f6iZ6ASWrpdyqlzzGUHS9pbw=="
-    },
     "cli": {
       "name": "@neon-rs/cli",
       "version": "0.0.169",
@@ -249,13 +153,13 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.168",
-        "@cargo-messages/darwin-arm64": "0.0.168",
-        "@cargo-messages/darwin-x64": "0.0.168",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.168",
-        "@cargo-messages/linux-x64-gnu": "0.0.168",
-        "@cargo-messages/win32-arm64-msvc": "0.0.168",
-        "@cargo-messages/win32-x64-msvc": "0.0.168"
+        "@cargo-messages/android-arm-eabi": "0.0.169",
+        "@cargo-messages/darwin-arm64": "0.0.169",
+        "@cargo-messages/darwin-x64": "0.0.169",
+        "@cargo-messages/linux-arm-gnueabihf": "0.0.169",
+        "@cargo-messages/linux-x64-gnu": "0.0.169",
+        "@cargo-messages/win32-arm64-msvc": "0.0.169",
+        "@cargo-messages/win32-x64-msvc": "0.0.169"
       }
     },
     "install": {
@@ -272,9 +176,9 @@
       }
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.168.tgz",
-      "integrity": "sha512-tXOX6a7Xxe5yrqS+V7FC3HqIsi9yzvHvnpreFZUt/PLpfQ7lRM40jeUlmB/6L94q+zuvmpCg/+VQWnLNxyRzig==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.169.tgz",
+      "integrity": "sha512-xrsotgaqqJxfw4sz2C5BJGYeRPhZ9KvI6aZkNjBToysWpxN2ScPWGOh/qiAlY/5mw8NUK0YBsKvn7VVI0ADD3A==",
       "cpu": [
         "arm"
       ],
@@ -284,9 +188,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.168.tgz",
-      "integrity": "sha512-KYgP9i1JIT6tGPgoUbG1rHDsAd3eUO8qWegX3qSutKPGnINMV/cu7LBnZz3BgLrjhsVDhQAOMN2CIDJ4l5OCAQ==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.169.tgz",
+      "integrity": "sha512-qmXFqPve4Uaz2iIM2sPG9+r5l2rPgAc+G5+ATDdxs4Pel4jCMDTpdrs+MjAzP4kNy0REw8jw55gCXPXz8O2u1g==",
       "cpu": [
         "arm64"
       ],
@@ -296,9 +200,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.168.tgz",
-      "integrity": "sha512-b/YsLHxK8KtMUIozTYE8y77SYNxaO8E1yUFKoeAJ1sMf70Sdv2aSQ6NP6l1J4TCsULqKOJg+MZMZp5jz3D94rA==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.169.tgz",
+      "integrity": "sha512-9KsOiOKagS6zdpyTU1TGMX/3a4AfpVXmIG0ym8WsCsUT5DMRVjK0xbW4Lo5gV2QwEVWCDGLuOWZKE4P4BOm8DQ==",
       "cpu": [
         "x64"
       ],
@@ -308,9 +212,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.168.tgz",
-      "integrity": "sha512-Iw6flzL1uChO4GyCh7amKreOU67kzk4GkOKaQzBZUgsrm+5kM+rBpGmETL5I4DLKtLhpehw31BG8v5Ac98QP9A==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.169.tgz",
+      "integrity": "sha512-JVotUXxyI/57MIyTVRC78r2F2USUKnqm55i//6VfskOwo0yGEm04Mh/+wRFaYZvt/eaeNymwuphBLCvvUzUpEQ==",
       "cpu": [
         "arm"
       ],
@@ -320,9 +224,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.168.tgz",
-      "integrity": "sha512-2atl00JD1vNlD7lCJe9znx5OZ+vzPrJn10BQjXtUcKj/ZaTBwXqr7lRomauLgMNAD3e/lk1UBvsEPwNhvmjH7A==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.169.tgz",
+      "integrity": "sha512-y9qB2HrlTqfFFNdVdcpIvpCzvGDWEPw/6XnSwJcYKkDZx1dx0nzPckW+oqI0SsapgFO1aootWZmvb1QCFiPPLQ==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +236,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.168.tgz",
-      "integrity": "sha512-+PUFD+sbmoZVfvqNgE3dXAB9uA34ZGjedC7mfq3E1S0Ab33+gbB3WI4PuL5cz6cPAw7iX5jn/F2z/XRpv50miQ==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.169.tgz",
+      "integrity": "sha512-fOhgXuzyS4cOVvE1WzEYPoAMcZPuWK0qURjFTTMNgfkt7mspSU58nrEbuzcKzJWhNs4JxVKIDFq+4o2BIeofsw==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +248,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.168.tgz",
-      "integrity": "sha512-J+7LLQnaE8/D2wYwoFDsK7vqXi8RYUYHsQ7uzX3g+BXN3H9k7Mi9EL5wiXDDtgyWRaarx1MFFrfO2r2PfD+nxg==",
+      "version": "0.0.169",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.169.tgz",
+      "integrity": "sha512-wr4Hc+fmvHFwbGmW0OE9rqknL+Ib7/LlqyPhq0Zz0wDEjnxKDSomV4NAmhg/636DK1sNMW+ppkR41lYzGg0jUg==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
This PR changes the implementation of `cargo-messages` to use the experimental `__UNSTABLE_proxy` instead of `lazy` API from `@neon-rs/load`.