### PR TITLE
Upgrade cargo-messages to use the new formats

### DIFF
--- a/pkgs/cargo-messages/package.json
+++ b/pkgs/cargo-messages/package.json
@@ -31,13 +31,13 @@
     "build": "cargo build --message-format=json --release | neon dist -v",
     "cross": "cross build --message-format=json --release | neon dist -v -m /target",
     "pack-target": "neon tarball -v",
-    "prepack": "neon update-targets -v 2>update-targets.log",
+    "prepack": "neon update-platforms -v 2>update-platforms.log",
     "version": "neon bump -v --binaries platforms"
   },
   "author": "David Herman <david.herman@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@neon-rs/cli": "^0.0.168"
+    "@neon-rs/cli": "^0.0.177"
   },
   "repository": {
     "type": "git",
@@ -52,12 +52,12 @@
   },
   "homepage": "https://github.com/dherman/neon-rs#readme",
   "dependencies": {
-    "@neon-rs/load": "^0.0.173"
+    "@neon-rs/load": "^0.0.177"
   },
   "neon": {
     "type": "source",
     "org": "@cargo-messages",
-    "targets": "extended",
+    "platforms": "extended",
     "load": "./lib/load.cjs"
   },
   "optionalDependencies": {

--- a/pkgs/package-lock.json
+++ b/pkgs/package-lock.json
@@ -21,17 +21,10 @@
       "version": "0.0.177",
       "license": "MIT",
       "dependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.177",
-        "@cargo-messages/darwin-arm64": "0.0.177",
-        "@cargo-messages/darwin-x64": "0.0.177",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.177",
-        "@cargo-messages/linux-x64-gnu": "0.0.177",
-        "@cargo-messages/win32-arm64-msvc": "0.0.177",
-        "@cargo-messages/win32-x64-msvc": "0.0.177",
-        "@neon-rs/load": "^0.0.173"
+        "@neon-rs/load": "^0.0.177"
       },
       "devDependencies": {
-        "@neon-rs/cli": "^0.0.168"
+        "@neon-rs/cli": "^0.0.177"
       },
       "optionalDependencies": {
         "@cargo-messages/android-arm-eabi": "0.0.177",
@@ -43,108 +36,6 @@
         "@cargo-messages/win32-x64-msvc": "0.0.177"
       }
     },
-    "cargo-messages/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.177.tgz",
-      "integrity": "sha512-On6fwJamdDik/BMR+4NVuVvEgMe1gb/QP2Menm3krf9ujTi7xfZrL1zT1DyWGt86wRHuDxCJrsfhnkzj01NaJA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.177.tgz",
-      "integrity": "sha512-4n64XOie1uzYscutsgJJIu9rpM+x9HepZDFKyBLWITZtTReCJ7DL7GHBbStzcCLD0ZBUKy21XpXgFk/0ojmwdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.177.tgz",
-      "integrity": "sha512-LPQ6+gvNQHYF3KFNnhdeGMWSbhPmpeWp08xeUNZIsl+TWcKTo7yO7JLqe18ozdxepaXcie5u/vQC8ntMuOHZnw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.177.tgz",
-      "integrity": "sha512-hZ/5w4dbRIvl3HgLQ/RDy3GOJJu+1SHE00NvIPUlzBu+88Usr8AgQIcxgwst5/w8AKXvMypIlAHaRYtN+qeFFQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.177.tgz",
-      "integrity": "sha512-d4aJCH4eH1hKo6+fngSg1B0Yv6eFozRFroOzQRFECNIvuwlK3Eox3cK42zCg51HnWy+kQJmqUhik6aIZFwIiOQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.177.tgz",
-      "integrity": "sha512-W+wkB4T+mikaRveQEtf2uwBQcWzS7a3j6GB4mFtRxG81lMOH7c8t7t1VzRJtUeA1dOihupKCskaIv1/6HmKdFw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cargo-messages/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.177.tgz",
-      "integrity": "sha512-q8x53a7/+Q6tBtp8GwPoOKIwjPSi//siv+OpHNTPH6ev/TyKxq/XB0RdfK5DrmZ4JUO4KgZ8lD/C2myPTHyl0g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cargo-messages/node_modules/@neon-rs/cli": {
-      "version": "0.0.168",
-      "resolved": "https://registry.npmjs.org/@neon-rs/cli/-/cli-0.0.168.tgz",
-      "integrity": "sha512-TOiuZyiW46FRwpBog8iCJ9+r5ibYRFDwWE5TXTZnpSEITW9HUOzJebIzEnngSWmcVRyD0MwqSPjgPc+PZKyAbQ==",
-      "dev": true,
-      "bin": {
-        "neon": "index.js"
-      },
-      "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.168",
-        "@cargo-messages/darwin-arm64": "0.0.168",
-        "@cargo-messages/darwin-x64": "0.0.168",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.168",
-        "@cargo-messages/linux-x64-gnu": "0.0.168",
-        "@cargo-messages/win32-arm64-msvc": "0.0.168",
-        "@cargo-messages/win32-x64-msvc": "0.0.168"
-      }
-    },
     "cargo-messages/node_modules/@neon-rs/cli/node_modules/@cargo-messages/android-arm-eabi": {
       "version": "0.0.168",
       "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.168.tgz",
@@ -152,8 +43,7 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "android"
       ]
@@ -165,8 +55,7 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "darwin"
       ]
@@ -178,8 +67,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "darwin"
       ]
@@ -191,8 +79,7 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "linux"
       ]
@@ -204,8 +91,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "linux"
       ]
@@ -217,8 +103,7 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "win32"
       ]
@@ -230,16 +115,10 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "os": [
         "win32"
       ]
-    },
-    "cargo-messages/node_modules/@neon-rs/load": {
-      "version": "0.0.173",
-      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.173.tgz",
-      "integrity": "sha512-fStUD9sgCA1tcqK9qfa0MLFLOnQ6uc93ExvnDjdSFbxx6hQdTujqE0UDwbed89BBRY1bEw9tjrrE31M9//CdOQ=="
     },
     "cli": {
       "name": "@neon-rs/cli",
@@ -249,13 +128,13 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.176",
-        "@cargo-messages/darwin-arm64": "0.0.176",
-        "@cargo-messages/darwin-x64": "0.0.176",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.176",
-        "@cargo-messages/linux-x64-gnu": "0.0.176",
-        "@cargo-messages/win32-arm64-msvc": "0.0.176",
-        "@cargo-messages/win32-x64-msvc": "0.0.176"
+        "@cargo-messages/android-arm-eabi": "0.0.177",
+        "@cargo-messages/darwin-arm64": "0.0.177",
+        "@cargo-messages/darwin-x64": "0.0.177",
+        "@cargo-messages/linux-arm-gnueabihf": "0.0.177",
+        "@cargo-messages/linux-x64-gnu": "0.0.177",
+        "@cargo-messages/win32-arm64-msvc": "0.0.177",
+        "@cargo-messages/win32-x64-msvc": "0.0.177"
       }
     },
     "install": {
@@ -272,9 +151,9 @@
       }
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.176.tgz",
-      "integrity": "sha512-Ws30udoY36puLlrTcFe3ft6vHBgta5vJJE35RlbUYKi2REN4lvpden4U4XgpEz3UyWAQepvu9jXl5lCoXCgG4g==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.177.tgz",
+      "integrity": "sha512-On6fwJamdDik/BMR+4NVuVvEgMe1gb/QP2Menm3krf9ujTi7xfZrL1zT1DyWGt86wRHuDxCJrsfhnkzj01NaJA==",
       "cpu": [
         "arm"
       ],
@@ -284,9 +163,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.176.tgz",
-      "integrity": "sha512-vl/gK2agBkvSo57R5ncvc+/QVJf7S2s2vBKDWO09yZXVrSWmzt/oOzNXLMSzq7F+nm03yHtA1Bm0JjQ0tnGPvw==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.177.tgz",
+      "integrity": "sha512-4n64XOie1uzYscutsgJJIu9rpM+x9HepZDFKyBLWITZtTReCJ7DL7GHBbStzcCLD0ZBUKy21XpXgFk/0ojmwdA==",
       "cpu": [
         "arm64"
       ],
@@ -296,9 +175,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.176.tgz",
-      "integrity": "sha512-ow6LMoyC2q0N57PfxDcGFsd+eM2IHTHOKEBZRdqJGn7YhmA3a5AEsmepRHhugvKIsv6SaJ9SARz3ZjisVaD4FQ==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.177.tgz",
+      "integrity": "sha512-LPQ6+gvNQHYF3KFNnhdeGMWSbhPmpeWp08xeUNZIsl+TWcKTo7yO7JLqe18ozdxepaXcie5u/vQC8ntMuOHZnw==",
       "cpu": [
         "x64"
       ],
@@ -308,9 +187,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.176.tgz",
-      "integrity": "sha512-piDQf2uC8vjrHD1LLL9xq1FJYuwXQ5R06FTOGLdYoMcvlnP/+AcSZ/GYMKXprFwxaUnlBPKGPkLilvle2Dl6AQ==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.177.tgz",
+      "integrity": "sha512-hZ/5w4dbRIvl3HgLQ/RDy3GOJJu+1SHE00NvIPUlzBu+88Usr8AgQIcxgwst5/w8AKXvMypIlAHaRYtN+qeFFQ==",
       "cpu": [
         "arm"
       ],
@@ -320,9 +199,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.176.tgz",
-      "integrity": "sha512-wk10YDV6/uCsa4ON8Hi4t24xHZ/9GR6AlR+wWSrKsIUGbGb3gk24AXpP9O0GpQ/b8Rp+INbZv8q90UykSkAuIw==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.177.tgz",
+      "integrity": "sha512-d4aJCH4eH1hKo6+fngSg1B0Yv6eFozRFroOzQRFECNIvuwlK3Eox3cK42zCg51HnWy+kQJmqUhik6aIZFwIiOQ==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +211,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.176.tgz",
-      "integrity": "sha512-esDYiFoecKFtVg4pJxHF6XCrS1Dd07a0ch7mJecr9msjEJoysz4DdgTCuUhLXTY6ifQrhtZBL9xdwRKtiWjoPA==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.177.tgz",
+      "integrity": "sha512-W+wkB4T+mikaRveQEtf2uwBQcWzS7a3j6GB4mFtRxG81lMOH7c8t7t1VzRJtUeA1dOihupKCskaIv1/6HmKdFw==",
       "cpu": [
         "arm64"
       ],
@@ -344,9 +223,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.176",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.176.tgz",
-      "integrity": "sha512-pGMswWlQ0E45LNOhapxTvl0H2Hks84D1d2laYc5KoYDbYeID8v9iwHFyPlk/Ovcw5uT4v+VAYnbJd19EJdm38g==",
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.177.tgz",
+      "integrity": "sha512-q8x53a7/+Q6tBtp8GwPoOKIwjPSi//siv+OpHNTPH6ev/TyKxq/XB0RdfK5DrmZ4JUO4KgZ8lD/C2myPTHyl0g==",
       "cpu": [
         "x64"
       ],

--- a/test/integration/sniff-bytes/package.json
+++ b/test/integration/sniff-bytes/package.json
@@ -36,7 +36,7 @@
   "neon": {
     "type": "source",
     "org": "@sniff-bytes",
-    "targets": [
+    "platforms": [
       "linux",
       "macos"
     ],


### PR DESCRIPTION
Upgrade `cargo-messages` to use the new formats from #23.