### PR TITLE
Another cargo-messages upgrade

### DIFF
--- a/pkgs/cargo-messages/platforms/android-arm-eabi/package.json
+++ b/pkgs/cargo-messages/platforms/android-arm-eabi/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "armv7-linux-androideabi",
     "node": "android-arm-eabi",
-    "platform": "android",
+    "os": "android",
     "arch": "arm",
     "abi": "eabi"
   }

--- a/pkgs/cargo-messages/platforms/darwin-arm64/package.json
+++ b/pkgs/cargo-messages/platforms/darwin-arm64/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "aarch64-apple-darwin",
     "node": "darwin-arm64",
-    "platform": "darwin",
+    "os": "darwin",
     "arch": "arm64",
     "abi": null
   }

--- a/pkgs/cargo-messages/platforms/darwin-x64/package.json
+++ b/pkgs/cargo-messages/platforms/darwin-x64/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "x86_64-apple-darwin",
     "node": "darwin-x64",
-    "platform": "darwin",
+    "os": "darwin",
     "arch": "x64",
     "abi": null
   }

--- a/pkgs/cargo-messages/platforms/linux-arm-gnueabihf/package.json
+++ b/pkgs/cargo-messages/platforms/linux-arm-gnueabihf/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "armv7-unknown-linux-gnueabihf",
     "node": "linux-arm-gnueabihf",
-    "platform": "linux",
+    "os": "linux",
     "arch": "arm",
     "abi": "gnueabihf"
   }

--- a/pkgs/cargo-messages/platforms/linux-x64-gnu/package.json
+++ b/pkgs/cargo-messages/platforms/linux-x64-gnu/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "x86_64-unknown-linux-gnu",
     "node": "linux-x64-gnu",
-    "platform": "linux",
+    "os": "linux",
     "arch": "x64",
     "abi": "gnu"
   }

--- a/pkgs/cargo-messages/platforms/win32-arm64-msvc/package.json
+++ b/pkgs/cargo-messages/platforms/win32-arm64-msvc/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "aarch64-pc-windows-msvc",
     "node": "win32-arm64-msvc",
-    "platform": "win32",
+    "os": "win32",
     "arch": "arm64",
     "abi": "msvc"
   }

--- a/pkgs/cargo-messages/platforms/win32-x64-msvc/package.json
+++ b/pkgs/cargo-messages/platforms/win32-x64-msvc/package.json
@@ -30,7 +30,7 @@
     "type": "binary",
     "rust": "x86_64-pc-windows-msvc",
     "node": "win32-x64-msvc",
-    "platform": "win32",
+    "os": "win32",
     "arch": "x64",
     "abi": "msvc"
   }


### PR DESCRIPTION
Upgrade cargo-messages: change `"platform"` to `"os"` key in binary modules (an oversight I missed in #24).