### PR TITLE
`neon bump --bins`

### DIFF
--- a/pkgs/cli/index.js
+++ b/pkgs/cli/index.js
@@ -2,6 +2,13 @@
 import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "module";
 /******/ var __webpack_modules__ = ({
 
+/***/ 8486:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+module.exports = require(__nccwpck_require__.ab + "index.node")
+
+/***/ }),
+
 /***/ 8938:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -45876,7 +45883,8 @@ const bump_OPTIONS = [
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
     { name: 'dir', alias: 'd', type: String, defaultValue: null },
     { name: 'workspaces', type: Boolean, defaultValue: false },
-    { name: 'binaries', alias: 'b', type: String, defaultValue: null }
+    { name: 'bins', alias: 'b', type: String, defaultValue: null },
+    { name: 'binaries', type: String, defaultValue: null }
 ];
 async function subdirs(dir) {
     const entries = await promises_namespaceObject.readdir(dir);
@@ -45895,7 +45903,7 @@ class Bump {
         return [
             { name: '-d, --dir <dir>', summary: 'Run `npm version <version>` in another directory.' },
             { name: '--workspaces', summary: 'Run `npm version --workspaces <version>` in the current directory.' },
-            { name: '-b, --binaries <dir>', summary: 'Run `npm version --force <version>` on all binary packages in <dir>.' },
+            { name: '-b, --bins <dir>', summary: 'Run `npm version --force <version>` on all binary packages in <dir>.' },
             { name: '', summary: 'The --force parameter causes npm to ignore `os` and `cpu` constraints in the binary packages\' manifests that might not match the current system.' },
             { name: '<version>', summary: 'The new package version. (Default: $npm_package_version)' },
             { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
@@ -45917,7 +45925,7 @@ class Bump {
         this._verbose = options.verbose;
         this._dir = options.dir || null;
         this._workspaces = options.workspaces;
-        this._binaries = options.binaries || null;
+        this._binaries = options.bins || options.binaries || null;
         if ([this._dir, this._workspaces, this._binaries].filter(x => !!x).length > 1) {
             throw new Error("Only one of --dir, --workspaces, or --binaries can be specified.");
         }
@@ -50281,14 +50289,6 @@ function printError(e) {
 /***/ ((module) => {
 
 module.exports = eval("require")("@cargo-messages/android-arm-eabi");
-
-
-/***/ }),
-
-/***/ 4404:
-/***/ ((module) => {
-
-module.exports = eval("require")("@cargo-messages/darwin-arm64");
 
 
 /***/ }),
@@ -65073,7 +65073,7 @@ module.exports = (__nccwpck_require__(8938)/* .proxy */ .sj)({
   'win32-x64-msvc': () => __nccwpck_require__(1324),
   'win32-arm64-msvc': () => __nccwpck_require__(7894),
   'darwin-x64': () => __nccwpck_require__(2990),
-  'darwin-arm64': () => __nccwpck_require__(4404),
+  'darwin-arm64': () => __nccwpck_require__(8486),
   'linux-x64-gnu': () => __nccwpck_require__(1316),
   'linux-arm-gnueabihf': () => __nccwpck_require__(5379),
   'android-arm-eabi': () => __nccwpck_require__(1738)

--- a/pkgs/package-lock.json
+++ b/pkgs/package-lock.json
@@ -67,19 +67,19 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.178",
-        "@cargo-messages/darwin-arm64": "0.0.178",
-        "@cargo-messages/darwin-x64": "0.0.178",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.178",
-        "@cargo-messages/linux-x64-gnu": "0.0.178",
-        "@cargo-messages/win32-arm64-msvc": "0.0.178",
-        "@cargo-messages/win32-x64-msvc": "0.0.178"
+        "@cargo-messages/android-arm-eabi": "0.0.179",
+        "@cargo-messages/darwin-arm64": "0.0.179",
+        "@cargo-messages/darwin-x64": "0.0.179",
+        "@cargo-messages/linux-arm-gnueabihf": "0.0.179",
+        "@cargo-messages/linux-x64-gnu": "0.0.179",
+        "@cargo-messages/win32-arm64-msvc": "0.0.179",
+        "@cargo-messages/win32-x64-msvc": "0.0.179"
       }
     },
     "cli/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.178.tgz",
-      "integrity": "sha512-uv7xqKbkcBrgKQjAx9URLBndeREkMfJ+WbJJAbgiT+Gqsh96IO7Q6z+cfTFg6BUnyYnwOHlyrskaiTPszeel2A==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.179.tgz",
+      "integrity": "sha512-5N2hzrQ437nuQh+v+nd5Pu6cVukCXWux/3e9JI3+ifQY2/XgBv5dy54Xw2xYFTqReQfN53cQPkXtTggyXu4Dvw==",
       "cpu": [
         "arm"
       ],
@@ -89,9 +89,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.178.tgz",
-      "integrity": "sha512-fJ9vYISoNiGF5cnEsLhqpJiUdMnGsvKn5yTSEhoHRqTQAzjgi3M7Rj6swAcbO0dy/vdCCPcgxe4XD2/XkyTJ/g==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.179.tgz",
+      "integrity": "sha512-6MNHQ9UZUQLqazVoOUdpSgpBHlDnLfeB6c1xYn44wLEC4vYB8W91IDrLXJIiEj1CrDPo29WoQ+YFb5ORFw/brg==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.178.tgz",
-      "integrity": "sha512-oP48XTtWHWv9C1jWnyypx5MDel3smhDjlujwkWrsdGOnlbbNZJyytVX0YAgEKqd5qL/oWPHgwsqNNOt7F942fQ==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.179.tgz",
+      "integrity": "sha512-dV6yqYacbEJeoUo7eLTfWVZrDz1ujMpExWHS6UczhRmsgALO4QHcR24N6X/eZGA+A0cT05t00Zb3IjlGwnp2fg==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.178.tgz",
-      "integrity": "sha512-L/zq9tujxabOH52w16hrK6fkMFJm2uUTM/BqXaNfF5lUHH9YMGzPkZHnadvCq1ixQFntnETa9C3gQsVKf6kFMQ==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.179.tgz",
+      "integrity": "sha512-Zlb38pm2IDck1bqz4Ko+V0Tf9Zb4ZXO/rPUSJSwhU3J+MPxJudNhT+3vUd6aCi0yU6NcMeJBVTbulQ+w38/Rdw==",
       "cpu": [
         "arm"
       ],
@@ -125,9 +125,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.178.tgz",
-      "integrity": "sha512-o3QuNiRUe7I4agn6384lKrnsS98pmQcZFe8jAfurCyZUxF3ItZUzLtth5a4r2a1VxugXoJspb9/fsR02LYKMyg==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.179.tgz",
+      "integrity": "sha512-t0PZUPnEf0/aJxwTtr3mRh+adPp/nl5WPaAaTmEp0CWzGNjZ2wTzo2au97Rz40kd9ru5WOLP5idR1XF87rYeJw==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +137,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.178.tgz",
-      "integrity": "sha512-/5mw07vjESxL9hSTCIUwSi8IowahQUfZ5iJxLoXbX9SvPwkjdypPf8tkXMSWYUsdWj6iz6irGnVnFYo56a8GIA==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.179.tgz",
+      "integrity": "sha512-5S5Lq9MGCJs6bwNaJA2Z2hrxbXEcU8nmGOMf0/tS4RCzIis2gT51K6JrSx/JEAGlGOf1Hjmfqn++12V5zCU9ag==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.178",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.178.tgz",
-      "integrity": "sha512-4+x1mEU9Q+cK+dNYfzqCMUdOP/nG2ppyee3BNT2wCJ0dcy7jh9fRhBgIZ8l+SaOeZwE2QikWcmiihlTVUBtLvQ==",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.179.tgz",
+      "integrity": "sha512-0F4HWopy8Y2oZDBbD+KrDQCbwbMX6kqRi9lsF9IwEgY2iRuHt3G0NcyzqYaIkTDxSm08962xuulZfs8IqjdMSA==",
       "cpu": [
         "x64"
       ],

--- a/src/cli/src/commands/bump.ts
+++ b/src/cli/src/commands/bump.ts
@@ -8,7 +8,8 @@ const OPTIONS = [
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
   { name: 'dir', alias: 'd', type: String, defaultValue: null },
   { name: 'workspaces', type: Boolean, defaultValue: false },
-  { name: 'binaries', alias: 'b', type: String, defaultValue: null }
+  { name: 'bins', alias: 'b', type: String, defaultValue: null },
+  { name: 'binaries', type: String, defaultValue: null }
 ];
 
 async function subdirs(dir: string): Promise<string[]> {
@@ -32,7 +33,7 @@ export default class Bump implements Command {
     return [
       { name: '-d, --dir <dir>', summary: 'Run `npm version <version>` in another directory.' },
       { name: '--workspaces', summary: 'Run `npm version --workspaces <version>` in the current directory.' },
-      { name: '-b, --binaries <dir>', summary: 'Run `npm version --force <version>` on all binary packages in <dir>.' },
+      { name: '-b, --bins <dir>', summary: 'Run `npm version --force <version>` on all binary packages in <dir>.' },
       { name: '', summary: 'The --force parameter causes npm to ignore `os` and `cpu` constraints in the binary packages\' manifests that might not match the current system.' },
       { name: '<version>', summary: 'The new package version. (Default: $npm_package_version)' },
       { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
@@ -57,7 +58,7 @@ export default class Bump implements Command {
     this._verbose = options.verbose;
     this._dir = options.dir || null;
     this._workspaces = options.workspaces;
-    this._binaries = options.binaries || null;
+    this._binaries = options.bins || options.binaries || null;
 
     if ([this._dir, this._workspaces, this._binaries].filter(x => !!x).length > 1) {
       throw new Error("Only one of --dir, --workspaces, or --binaries can be specified.");


### PR DESCRIPTION
This PR changes `neon bump --binaries` to `neon bump --bins` for consistency with `create-neon`.

It leaves `--binaries` support for backwards compatibility.