### PR TITLE
Avoid boilerplate in `cargo-messages` wrapper declaration module

### DIFF
--- a/pkgs/cargo-messages/types/index.d.mts
+++ b/pkgs/cargo-messages/types/index.d.mts
@@ -1,1 +1,10 @@
-export { CrateType, CargoArtifact, CargoMessageOptions, CargoMessages, CargoReader, CargoReaderOptions, CompilerArtifact, CargoMessage } from './index.d.cts';
+export {
+  CrateType,
+  CargoArtifact,
+  CargoMessageOptions,
+  CargoMessages,
+  CargoReader,
+  CargoReaderOptions,
+  CompilerArtifact,
+  CargoMessage
+} from './index.d.cts';

--- a/pkgs/cargo-messages/types/index.d.mts
+++ b/pkgs/cargo-messages/types/index.d.mts
@@ -1,3 +1,1 @@
-import { CrateType, CargoArtifact, CargoMessageOptions, CargoMessages, CargoReader, CargoReaderOptions, CompilerArtifact, CargoMessage } from './index.d.cts';
-
-export { CrateType, CargoArtifact, CargoMessageOptions, CargoMessages, CargoReader, CargoReaderOptions, CompilerArtifact, CargoMessage };
+export { CrateType, CargoArtifact, CargoMessageOptions, CargoMessages, CargoReader, CargoReaderOptions, CompilerArtifact, CargoMessage } from './index.d.cts';


### PR DESCRIPTION
Use `export ... from` to avoid duplication in `index.d.mts`.