### PR TITLE
Change `sniff-bytes` into a TS project

### DIFF
--- a/test/integration/sniff-bytes/.gitignore
+++ b/test/integration/sniff-bytes/.gitignore
@@ -4,3 +4,4 @@ target
 npm-debug.log*
 dist
 package-lock.json
+lib

--- a/test/integration/sniff-bytes/.npmignore
+++ b/test/integration/sniff-bytes/.npmignore
@@ -1,1 +1,6 @@
-npm
+platforms
+src
+target
+Cargo.lock
+Cargo.toml
+tsconfig.json

--- a/test/integration/sniff-bytes/lib/index.cjs
+++ b/test/integration/sniff-bytes/lib/index.cjs
@@ -1,5 +1,0 @@
-const addon = require('./load.cjs');
-
-module.exports = {
-  sniffBytes: addon.sniffBytes
-};

--- a/test/integration/sniff-bytes/lib/index.mjs
+++ b/test/integration/sniff-bytes/lib/index.mjs
@@ -1,1 +1,0 @@
-export { sniffBytes } from './index.cjs';

--- a/test/integration/sniff-bytes/package.json
+++ b/test/integration/sniff-bytes/package.json
@@ -7,29 +7,31 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./types/index.d.mts",
+        "types": "./lib/index.d.mts",
         "default": "./lib/index.mjs"
       },
       "require": {
-        "types": "./types/index.d.cts",
+        "types": "./lib/index.d.cts",
         "default": "./lib/index.cjs"
       }
     }
   },
-  "types": "./types/index.d.cts",
+  "types": "./lib/index.d.cts",
   "main": "./lib/index.cjs",
   "files": [
-    "lib/index.cjs",
-    "lib/load.cjs",
-    "lib/index.mjs",
-    "types/index.d.cts",
-    "types/index.d.mts"
+    "lib/**/*.cjs",
+    "lib/**/*.d.cts",
+    "lib/**/*.mjs",
+    "lib/**/*.d.mts",
+    "lib/**/*.js",
+    "lib/**/*.d.ts"
   ],
   "scripts": {
-    "test": "cargo test",
-    "debug": "cargo build --message-format=json | neon dist",
-    "build": "cargo build --message-format=json --release | neon dist -v -n sniff-bytes",
-    "cross": "cross build --message-format=json --release | neon dist -v -n sniff-bytes -m /target",
+    "tsc": "tsc",
+    "test": "tsc && cargo test",
+    "debug": "tsc && cargo build --message-format=json | neon dist",
+    "build": "tsc && cargo build --message-format=json --release | neon dist -v -n sniff-bytes",
+    "cross": "tsc && cross build --message-format=json --release | neon dist -v -n sniff-bytes -m /target",
     "prepack": "neon update-platforms -v"
   },
   "license": "MIT",
@@ -44,7 +46,8 @@
   },
   "devDependencies": {
     "@neon-rs/cli": "*",
-    "@tsconfig/node16": "^16.1.0",
+    "@tsconfig/node18": "^18.2.2",
+    "@types/node": "^20.10.4",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/test/integration/sniff-bytes/ts/index.cts
+++ b/test/integration/sniff-bytes/ts/index.cts
@@ -1,4 +1,4 @@
-const addon = require('./load.js');
+const addon = require('./load.cjs');
 
 export type FileFormat = {
   name: string,

--- a/test/integration/sniff-bytes/ts/index.cts
+++ b/test/integration/sniff-bytes/ts/index.cts
@@ -1,0 +1,12 @@
+const addon = require('./load.js');
+
+export type FileFormat = {
+  name: string,
+  shortName: string | null,
+  mediaType: string,
+  extension: string
+};
+
+export function sniffBytes(buffer: ArrayBuffer): FileFormat {
+  return addon.sniffBytes(buffer);
+}

--- a/test/integration/sniff-bytes/ts/index.mts
+++ b/test/integration/sniff-bytes/ts/index.mts
@@ -1,0 +1,1 @@
+export { sniffBytes, FileFormat } from './index.cjs';

--- a/test/integration/sniff-bytes/ts/load.cts
+++ b/test/integration/sniff-bytes/ts/load.cts
@@ -1,9 +1,4 @@
-import { proxy } from '@neon-rs/load';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-
-export default proxy({
+module.exports = require('@neon-rs/load').proxy({
   platforms: {
     'linux-x64-gnu': () => require('@sniff-bytes/linux-x64-gnu'),
     'darwin-arm64': () => require('@sniff-bytes/darwin-arm64')

--- a/test/integration/sniff-bytes/ts/load.ts
+++ b/test/integration/sniff-bytes/ts/load.ts
@@ -1,5 +1,10 @@
-module.exports = require('@neon-rs/load').proxy({
-  targets: {
+import { proxy } from '@neon-rs/load';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export default proxy({
+  platforms: {
     'linux-x64-gnu': () => require('@sniff-bytes/linux-x64-gnu'),
     'darwin-arm64': () => require('@sniff-bytes/darwin-arm64')
   },

--- a/test/integration/sniff-bytes/tsconfig.json
+++ b/test/integration/sniff-bytes/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json"
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "module": "node16",
+    "declaration": true,
+    "outDir": "lib",
+  },
+  "exclude": ["lib"]
 }

--- a/test/integration/sniff-bytes/types/index.d.cts
+++ b/test/integration/sniff-bytes/types/index.d.cts
@@ -1,8 +1,0 @@
-export type FileFormat = {
-  name: string,
-  shortName: string | null,
-  mediaType: string,
-  extension: string
-};
-
-export function sniffBytes(buffer: ArrayBuffer): FileFormat;

--- a/test/integration/sniff-bytes/types/index.d.mts
+++ b/test/integration/sniff-bytes/types/index.d.mts
@@ -1,3 +1,0 @@
-import { FileFormat, sniffBytes } from './index.d.cts';
-
-export { FileFormat, sniffBytes };


### PR DESCRIPTION
Change `sniff-bytes` into a full TypeScript project:
- source files are in `ts/`
- all destination files (`.{c,m}?js`, `.d.{c,m}?ts`) go in `lib/`