### PR TITLE
Upgrade to `build` action v0.6.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.2
+        uses: neon-actions/build@v0.6.3
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.5
+        uses: neon-actions/build@v0.6.6
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6
+        uses: neon-actions/build@v0.6.1
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.1
+        uses: neon-actions/build@v0.6.2
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.3
+        uses: neon-actions/build@v0.6.4
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.6
+        uses: neon-actions/build@v0.6.7
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.6.4
+        uses: neon-actions/build@v0.6.5
         with:
           working-directory: ./pkgs/cargo-messages
           platform: linux-x64-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,12 @@ jobs:
         shell: bash
         run: npm ci --verbose
       - name: Build
-        uses: neon-actions/build@v0.5
+        uses: neon-actions/build@v0.6
         with:
           working-directory: ./pkgs/cargo-messages
-          input-directory: ${{ env.NEON_PLATFORMS_DIR }}/linux-x64-gnu
+          platform: linux-x64-gnu
           node-version: ${{ env.NODE_VERSION }}
           use-cross: false
-          npm-publish: false
           github-release: false
       - name: Start npm Proxy
         shell: bash
@@ -59,7 +58,7 @@ jobs:
         shell: bash
         working-directory: ./test/integration/proxy
         timeout-minutes: 3
-        run: ./publish.sh
+        run: ./publish.sh linux-x64-gnu
       # Since package integrity checksums may vary depending on what versions
       # are available in the proxy registry, we don't put the lockfile for this
       # test in source control. This means we have to use `npm i`, not `npm ci`.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-        target: [darwin-arm64, darwin-x64]
+        platform: [darwin-arm64, darwin-x64]
     runs-on: macos-latest
     permissions:
       contents: write
@@ -63,19 +63,17 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.5
+        uses: neon-actions/build@v0.6
         with:
           working-directory: ./pkgs/cargo-messages
-          input-directory: ${{ env.NEON_PLATFORMS_DIR }}/${{ matrix.target }}
           node-version: ${{ env.NODE_VERSION }}
-          target: ${{ matrix.target }}
-          npm-publish: false
+          platform: ${{ matrix.platform }}
           github-release: ${{ needs.setup.outputs.action == 'publish' }}
       - name: Inspect
         shell: bash
         run: |
           cd dist
-          tar -zxvf cargo-messages-${{ matrix.target }}-*.tgz package/index.node
+          tar -zxvf cargo-messages-${{ matrix.platform }}-*.tgz package/index.node
           lipo -info ./package/index.node | sed -En -e 's/^(Non-|Architectures in the )fat file: .+( is architecture| are): (.*)$/\3/p'
         working-directory: ./pkgs/cargo-messages
 
@@ -84,7 +82,7 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-        target: [win32-x64-msvc, win32-arm64-msvc]
+        platform: [win32-x64-msvc, win32-arm64-msvc]
     runs-on: windows-latest
     permissions:
       contents: write
@@ -108,12 +106,11 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.5
+        uses: neon-actions/build@v0.6
         with:
           working-directory: ./pkgs/cargo-messages
-          input-directory: ${{ env.NEON_PLATFORMS_DIR }}/${{ matrix.target }}
+          platform: ${{ matrix.platform }}
           node-version: ${{ env.NODE_VERSION }}
-          npm-publish: false
           github-release: ${{ needs.setup.outputs.action == 'publish' }}
 
   other-builds:
@@ -121,7 +118,7 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-        target: [linux-arm-gnueabihf, linux-x64-gnu, android-arm-eabi]
+        platform: [linux-arm-gnueabihf, linux-x64-gnu, android-arm-eabi]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -145,14 +142,12 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.5
+        uses: neon-actions/build@v0.6
         with:
           working-directory: ./pkgs/cargo-messages
-          input-directory: ${{ env.NEON_PLATFORMS_DIR }}/${{ matrix.target }}
           node-version: ${{ env.NODE_VERSION }}
           use-cross: true
-          target: ${{ matrix.target }}
-          npm-publish: false
+          platform: ${{ matrix.platform }}
           github-release: ${{ needs.setup.outputs.action == 'publish' }}
 
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6
+        uses: neon-actions/build@v0.6.1
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6
+        uses: neon-actions/build@v0.6.1
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6
+        uses: neon-actions/build@v0.6.1
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.1
+        uses: neon-actions/build@v0.6.2
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.1
+        uses: neon-actions/build@v0.6.2
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.1
+        uses: neon-actions/build@v0.6.2
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.6
+        uses: neon-actions/build@v0.6.7
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.6
+        uses: neon-actions/build@v0.6.7
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.6
+        uses: neon-actions/build@v0.6.7
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.3
+        uses: neon-actions/build@v0.6.4
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.3
+        uses: neon-actions/build@v0.6.4
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.3
+        uses: neon-actions/build@v0.6.4
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.2
+        uses: neon-actions/build@v0.6.3
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.2
+        uses: neon-actions/build@v0.6.3
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.2
+        uses: neon-actions/build@v0.6.3
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.4
+        uses: neon-actions/build@v0.6.5
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.4
+        uses: neon-actions/build@v0.6.5
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.4
+        uses: neon-actions/build@v0.6.5
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.5
+        uses: neon-actions/build@v0.6.6
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}
@@ -106,7 +106,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.5
+        uses: neon-actions/build@v0.6.6
         with:
           working-directory: ./pkgs/cargo-messages
           platform: ${{ matrix.platform }}
@@ -142,7 +142,7 @@ jobs:
           git branch -a
           git status
       - name: Build
-        uses: neon-actions/build@v0.6.5
+        uses: neon-actions/build@v0.6.6
         with:
           working-directory: ./pkgs/cargo-messages
           node-version: ${{ env.NODE_VERSION }}

--- a/pkgs/cli/index.js
+++ b/pkgs/cli/index.js
@@ -46729,7 +46729,7 @@ class Tarball {
             this.log(`npm pack failed with exit code ${result.exitCode}`);
             process.exit(result.exitCode);
         }
-        // FIXME: comment linking to the npm issue this fixes
+        // NOTE: This is a workaround for https://github.com/npm/cli/issues/3405
         const tarball = JSON.parse(result.stdout)[0].filename.replace('@', '').replace('/', '-');
         this.log(`tarball filename: ${tarball}`);
         const dest = external_node_path_namespaceObject.join(this._outDir, tarball);
@@ -47154,7 +47154,6 @@ function summaries() {
         { name: CommandName.Help, summary: Help.summary() },
         { name: CommandName.Dist, summary: Dist.summary() },
         { name: CommandName.Bump, summary: Bump.summary() },
-        { name: CommandName.Tarball, summary: Tarball.summary() },
         { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
         { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
         { name: CommandName.RustTarget, summary: RustTarget.summary() },

--- a/src/cli/src/command.ts
+++ b/src/cli/src/command.ts
@@ -33,7 +33,7 @@ export enum CommandName {
   Dist = 'dist',
   Bump = 'bump',
   PackBuild = 'pack-build', // DEPRECATED(0.1)
-  Tarball = 'tarball',
+  Tarball = 'tarball', // DEPRECATED(0.1)
   AddTarget = 'add-target', // DEPRECATED(0.1)
   AddPlatform = 'add-platform',
   InstallBuilds = 'install-builds', // DEPRECATED(0.1)
@@ -60,7 +60,7 @@ const COMMANDS: Record<CommandName, CommandClass> = {
   [CommandName.Dist]: Dist,
   [CommandName.Bump]: Bump,
   [CommandName.PackBuild]: Tarball, // DEPRECATED(0.1)
-  [CommandName.Tarball]: Tarball,
+  [CommandName.Tarball]: Tarball, // DEPRECATED(0.1)
   [CommandName.AddTarget]: AddPlatform, // DEPRECATED(0.1)
   [CommandName.AddPlatform]: AddPlatform,
   [CommandName.InstallBuilds]: UpdatePlatforms, // DEPRECATED(0.1)
@@ -79,7 +79,6 @@ export function summaries(): CommandDetail[] {
     { name: CommandName.Help, summary: Help.summary() },
     { name: CommandName.Dist, summary: Dist.summary() },
     { name: CommandName.Bump, summary: Bump.summary() },
-    { name: CommandName.Tarball, summary: Tarball.summary() },
     { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
     { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
     { name: CommandName.RustTarget, summary: RustTarget.summary() },

--- a/src/cli/src/commands/tarball.ts
+++ b/src/cli/src/commands/tarball.ts
@@ -146,7 +146,7 @@ export default class Tarball implements Command {
       process.exit(result.exitCode);
     }
 
-    // FIXME: comment linking to the npm issue this fixes
+    // NOTE: This is a workaround for https://github.com/npm/cli/issues/3405
     const tarball = JSON.parse(result.stdout)[0].filename.replace('@', '').replace('/', '-');
     this.log(`tarball filename: ${tarball}`);
 

--- a/test/integration/proxy/publish.sh
+++ b/test/integration/proxy/publish.sh
@@ -29,7 +29,7 @@ npm i
 npm run build
 mkdir -p dist
 # NOTE: `xargs basename` is a workaround for https://github.com/npm/cli/issues/3405
-PACKAGE_TARBALL=$((cd platforms/$CURRENT_PLATFORM && npm pack --json | jq '.[0].filename' | xargs basename))
+PACKAGE_TARBALL=$( (cd platforms/$CURRENT_PLATFORM && npm pack --json | jq '.[0].filename' | xargs basename) )
 mv ./platforms/${CURRENT_PLATFORM}/${PACKAGE_TARBALL} ./dist/
 npm publish ./dist/${PACKAGE_TARBALL} --registry $PROXY_SERVER
 npm publish --registry $PROXY_SERVER

--- a/test/integration/proxy/publish.sh
+++ b/test/integration/proxy/publish.sh
@@ -4,6 +4,17 @@ PROXY_DIR=$(dirname $0)
 cd ${PROXY_DIR}/../../..
 ROOT_DIR=$(pwd)
 
+if [ $# -lt 1 ]; then
+  echo -e 'usage: publish.sh <platform>'
+  echo -e ''
+  echo -e '  <platform>  Node platform name'
+  echo -e ''
+  echo -e 'error: missing <platform> argument'
+  exit 1
+fi
+
+CURRENT_PLATFORM=$1
+
 PROXY_USER=ci
 PROXY_PASSWORD=dummycipassword
 PROXY_EMAIL=ci@neon-bindings.com
@@ -17,6 +28,8 @@ cd test/integration/sniff-bytes
 npm i
 npm run build
 mkdir -p dist
-PACKAGE_TARBALL=$(npx neon tarball --out-dir dist | tail -1)
-npm publish ./${PACKAGE_TARBALL} --registry $PROXY_SERVER
+# NOTE: `xargs basename` is a workaround for https://github.com/npm/cli/issues/3405
+PACKAGE_TARBALL=$((cd platforms/$CURRENT_PLATFORM && npm pack --json | jq '.[0].filename' | xargs basename))
+mv ./platforms/${CURRENT_PLATFORM}/${PACKAGE_TARBALL} ./dist/
+npm publish ./dist/${PACKAGE_TARBALL} --registry $PROXY_SERVER
 npm publish --registry $PROXY_SERVER

--- a/test/integration/proxy/publish.sh
+++ b/test/integration/proxy/publish.sh
@@ -26,7 +26,7 @@ npx npm-cli-adduser -u ${PROXY_USER} -p ${PROXY_PASSWORD} -e ${PROXY_EMAIL} -r $
 
 cd test/integration/sniff-bytes
 npm i
-npm run build
+npm run build -- -o platforms/${CURRENT_PLATFORM}/index.node
 mkdir -p dist
 # NOTE: `xargs basename` is a workaround for https://github.com/npm/cli/issues/3405
 PACKAGE_TARBALL=$( (cd platforms/$CURRENT_PLATFORM && npm pack --json | jq '.[0].filename' | xargs basename) )


### PR DESCRIPTION
Upgrade to [neon-actions/build](https://github.com/neon-actions/build) action v0.6.7:
- Easier-to-understand YAML API: `platform` is all you need, no more `input-directory`
- `matrix.target` becomes `matrix.platform`
- Eliminate all uses of `neon tarball` command and use `npm pack` directly
- Deprecate the `neon tarball` command
