### PR TITLE
New command: `list-platforms`, `current-platform`

### DIFF
--- a/pkgs/package-lock.json
+++ b/pkgs/package-lock.json
@@ -67,19 +67,19 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.0.180",
-        "@cargo-messages/darwin-arm64": "0.0.180",
-        "@cargo-messages/darwin-x64": "0.0.180",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.180",
-        "@cargo-messages/linux-x64-gnu": "0.0.180",
-        "@cargo-messages/win32-arm64-msvc": "0.0.180",
-        "@cargo-messages/win32-x64-msvc": "0.0.180"
+        "@cargo-messages/android-arm-eabi": "0.0.181",
+        "@cargo-messages/darwin-arm64": "0.0.181",
+        "@cargo-messages/darwin-x64": "0.0.181",
+        "@cargo-messages/linux-arm-gnueabihf": "0.0.181",
+        "@cargo-messages/linux-x64-gnu": "0.0.181",
+        "@cargo-messages/win32-arm64-msvc": "0.0.181",
+        "@cargo-messages/win32-x64-msvc": "0.0.181"
       }
     },
     "cli/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.180.tgz",
-      "integrity": "sha512-U4JyrnorbT24dDliie3miNGDjaqq39It2pgvul2Gcbs/gUOSvquWZCp0egUvCrjYykFaW6WCcZRlykGVWvS6dA==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.0.181.tgz",
+      "integrity": "sha512-FlBx4ECybiKt0HldMGXrAggv+kmOPnaOoJQyG73qF+k52A/TIfzNKgSNQAq7CeefN5xgIDzwEaZavuw+hisQRw==",
       "cpu": [
         "arm"
       ],
@@ -89,9 +89,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.180.tgz",
-      "integrity": "sha512-tOeMcXMc+4fTHQoKgCVtvisHfLfPHG687J6+auWs4KsUf/Gy4wriw48Y2p8p8tmhAZwHbIeIrRLuu6mhcmPoyQ==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.181.tgz",
+      "integrity": "sha512-p9yGCbue0xt4iP/B+MSVUg38XPPWGuF5gSnhAZHuwNoo8IduTs86xcgvNprp+gox9rmnWeJd9h+cIdLrH0BEIA==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +101,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.180.tgz",
-      "integrity": "sha512-d/DILLGX+64iX8ic0jdqgewsuzJ6ahTPBc0sDh5XEo9iqjIjIRFVrYT2uxYq1/HoVssF4GvCmkwdLGcYIMHWqw==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.181.tgz",
+      "integrity": "sha512-MC4fyvIBzk6hzAALlefA9S2dLQRHLcDIvO4hiiCojeei1YrabuMSMUC8Sa8f9Kp49FugyYIn1p0T167U+1HOOQ==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.180.tgz",
-      "integrity": "sha512-q8OlpEP4Qnr3AjLvvR39bC/n7vh8O+mN0XBIxn+7kGerF2ZYhvRtF00eBRoUO+5WXL1vXvFBlDajwTIqdI7rfQ==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.181.tgz",
+      "integrity": "sha512-kcHo44OewuTJT0Rf/TFVoPb/FPMDBbn1MepMHcNm2MltXywyI2lmE1ijoN4bqgSyLtuwyqcFXOOXW236CkHhDA==",
       "cpu": [
         "arm"
       ],
@@ -125,9 +125,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.180.tgz",
-      "integrity": "sha512-QFiBXW37JLzx+qoKu5RXmENNW6K9MExdPRJHh/qjF0K22L9bzAkc+W4XfVfl3KUWZYxhR7AhFCbhRu5AEQCSdw==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.181.tgz",
+      "integrity": "sha512-yuksf5TzT3/itDqGf8j8WJfklJWy+0qLPRu8h7wvJnSj1Hmsj8qSiDRM8mIE0NqIRFnNr2zH0uyG2mQBGCKb3A==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +137,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.180.tgz",
-      "integrity": "sha512-RH41Uc6uxkMe68Y0i8VCw9bm0NsPSxv561AmzSxWapq8K5etHjXEYIaty7M7Ly2O+naY/evP2jjvBQyngWm9Pg==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.181.tgz",
+      "integrity": "sha512-J5yZdMiLKdfhzy2mwouzxoQwbTE0AR9xIecsYSxs3S+Twr2suMOBJ3T5ak9hFm1IsE+JpWSAUtGjFpnWU6cogg==",
       "cpu": [
         "arm64"
       ],
@@ -149,9 +149,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.180",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.180.tgz",
-      "integrity": "sha512-nTNiRXDBHANEqmtRLv7fyeltCBwlGfHlwN54cu+H9Jkhx3jkZc8Yjm7qyYIO5TJSnp8J/C9UF1ukOOWFcwXSBQ==",
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.181.tgz",
+      "integrity": "sha512-XgqZIs4OXDfxdwVp9tWzVjyg3X9NeK/UuprBHkxPZOQ+ZfkrKT25uNofi/elMx8vcvNpwbkRbYgQmnGK0uR4Ig==",
       "cpu": [
         "x64"
       ],

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -57,6 +57,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@neon-rs/load": "^0.0.181",
     "cargo-messages": "^0.0.181",
     "chalk": "^5.2.0",
     "command-line-args": "^5.2.1",

--- a/src/cli/src/command.ts
+++ b/src/cli/src/command.ts
@@ -3,6 +3,8 @@ import Bump from './commands/bump.js';
 import Tarball from './commands/tarball.js';
 import AddPlatform from './commands/add-platform.js';
 import UpdatePlatforms from './commands/update-platforms.js';
+import ListPlatforms from './commands/list-platforms.js';
+import CurrentPlatform from './commands/current-platform.js';
 import RustTarget from './commands/rust-target.js';
 import Preset from './commands/preset.js';
 import Help from './commands/help.js';
@@ -39,7 +41,9 @@ export enum CommandName {
   InstallBuilds = 'install-builds', // DEPRECATED(0.1)
   UpdateTargets = 'update-targets', // DEPRECATED(0.1)
   UpdatePlatforms = 'update-platforms',
-  RustTarget = 'rust-target',
+  ListPlatforms = 'list-platforms',
+  CurrentPlatform = 'current-platform',
+  RustTarget = 'rust-target', // DEPRECATED(0.1)
   Preset = 'preset'
 };
 
@@ -66,7 +70,9 @@ const COMMANDS: Record<CommandName, CommandClass> = {
   [CommandName.InstallBuilds]: UpdatePlatforms, // DEPRECATED(0.1)
   [CommandName.UpdateTargets]: UpdatePlatforms, // DEPRECATED(0.1)
   [CommandName.UpdatePlatforms]: UpdatePlatforms,
-  [CommandName.RustTarget]: RustTarget,
+  [CommandName.ListPlatforms]: ListPlatforms,
+  [CommandName.CurrentPlatform]: CurrentPlatform,
+  [CommandName.RustTarget]: RustTarget, // DEPRECATED(0.1)
   [CommandName.Preset]: Preset
 };
 
@@ -81,7 +87,8 @@ export function summaries(): CommandDetail[] {
     { name: CommandName.Bump, summary: Bump.summary() },
     { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
     { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
-    { name: CommandName.RustTarget, summary: RustTarget.summary() },
+    { name: CommandName.ListPlatforms, summary: ListPlatforms.summary() },
+    { name: CommandName.CurrentPlatform, summary: CurrentPlatform.summary() },
     { name: CommandName.Preset, summary: Preset.summary() }
   ];
 }

--- a/src/cli/src/commands/current-platform.ts
+++ b/src/cli/src/commands/current-platform.ts
@@ -1,0 +1,51 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../command.js';
+import { currentPlatform } from '@neon-rs/load';
+
+const OPTIONS = [
+  { name: 'json', type: Boolean, defaultValue: false },
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class CurrentPlatform implements Command {
+  static summary(): string { return 'Display the current device\'s platform info.'; }
+  static syntax(): string { return 'neon current-platform [--json] [-v]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '--json', summary: 'Display platform info in JSON format. (Default: false)' },
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void { }
+
+  private _json: boolean;
+  private _verbose: boolean;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv });
+
+    this._json = options.json || false;
+    this._verbose = !!options.verbose;
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon current-platform] " + msg);
+    }
+  }
+
+  async run() {
+    if (this._json) {
+      const [os, arch, abi] = currentPlatform().split('-');
+      const json = {
+        os,
+        arch,
+        abi: abi || null
+      };
+      console.log(JSON.stringify(json, null, 2));
+    } else {
+      console.log(currentPlatform());
+    }
+  }
+}

--- a/src/cli/src/commands/list-platforms.ts
+++ b/src/cli/src/commands/list-platforms.ts
@@ -1,0 +1,41 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../command.js';
+import { SourceManifest } from '../manifest.js';
+
+const OPTIONS = [
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class ListPlatforms implements Command {
+  static summary(): string { return 'Display the JSON target data for this project\'s platforms.'; }
+  static syntax(): string { return 'neon list-platforms [-v]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void { }
+  
+  private _verbose: boolean;
+  
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv });
+  
+    this._verbose = !!options.verbose;
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon list-platforms] " + msg);
+    }
+  }
+  
+  async run() {
+    this.log(`reading package.json`);
+    const sourceManifest = await SourceManifest.load();
+    this.log(`manifest: ${sourceManifest.stringify()}`);
+    const platforms = sourceManifest.allPlatforms();
+    console.log(JSON.stringify(platforms, null, 2));
+  }
+}

--- a/src/cli/src/commands/preset.ts
+++ b/src/cli/src/commands/preset.ts
@@ -3,31 +3,28 @@ import { Command, CommandDetail, CommandSection } from '../command.js';
 import { assertIsPlatformPreset, expandPlatformPreset, PlatformPreset } from '../platform.js';
 
 const OPTIONS = [
-  { name: 'pretty', alias: 'p', type: Boolean, defaultValue: false },
+  { name: 'pretty', alias: 'p', type: Boolean, defaultValue: true },
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
 
 export default class Preset implements Command {
   static summary(): string { return 'Display the JSON target data for a platform preset.'; }
-  static syntax(): string { return 'neon preset [-p] [-v] <preset>'; }
+  static syntax(): string { return 'neon preset [-v] <preset>'; }
   static options(): CommandDetail[] {
     return [
       { name: '<preset>', summary: 'The target family preset to look up.' },
-      { name: '-p, --pretty', summary: 'Pretty-print the JSON output. (Default: false)' },
       { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
     ];
   }
   static seeAlso(): CommandDetail[] | void { }
   static extraSection(): CommandSection | void { }
   
-  private _pretty: boolean;
   private _verbose: boolean;
   private _preset: PlatformPreset;
   
   constructor(argv: string[]) {
     const options = commandLineArgs(OPTIONS, { argv, partial: true });
   
-    this._pretty = options.pretty || false;
     this._verbose = !!options.verbose;
 
     if (!options._unknown || options._unknown.length === 0) {
@@ -50,9 +47,6 @@ export default class Preset implements Command {
   
   async run() {
     const map = expandPlatformPreset(this._preset);
-    const output = this._pretty
-      ? JSON.stringify(map, null, 2)
-      : JSON.stringify(map);
-    console.log(output);
+    console.log(JSON.stringify(map, null, 2));
   }
 }

--- a/src/cli/src/manifest.ts
+++ b/src/cli/src/manifest.ts
@@ -431,6 +431,10 @@ export class SourceManifest extends AbstractManifest {
     return undefined;
   }
 
+  allPlatforms(): PlatformMap {
+    return this._expandedPlatforms;
+  }
+
   rustTargetFor(node: NodePlatform): RustTarget | undefined {
     return this._expandedPlatforms[node];
   }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.0.181",
       "license": "MIT",
       "dependencies": {
+        "@neon-rs/load": "^0.0.181",
         "cargo-messages": "^0.0.181",
         "chalk": "^5.2.0",
         "command-line-args": "^5.2.1",
@@ -149,9 +150,9 @@
       ]
     },
     "cli/node_modules/@neon-rs/load": {
-      "version": "0.0.177",
-      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.177.tgz",
-      "integrity": "sha512-J8OG1kHqF5YXJNLyiWekKZukBvx1INz1s85UH6yRzcXOXgPiXE0bTY1qSFdlDgVO9oQ3WZMOGUbhGO/ox2vm3Q=="
+      "version": "0.0.181",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.181.tgz",
+      "integrity": "sha512-teRPDgstiKQE91WsvnW4mAdTSEPUdi9a8b98IPVhm2R5MT1elzxeTFidP56JfqtzocZFYDetCwEcPB3xCIR4pg=="
     },
     "cli/node_modules/cargo-messages": {
       "version": "0.0.181",
@@ -253,6 +254,11 @@
       "os": [
         "win32"
       ]
+    },
+    "cli/node_modules/cargo-messages/node_modules/@neon-rs/load": {
+      "version": "0.0.177",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.177.tgz",
+      "integrity": "sha512-J8OG1kHqF5YXJNLyiWekKZukBvx1INz1s85UH6yRzcXOXgPiXE0bTY1qSFdlDgVO9oQ3WZMOGUbhGO/ox2vm3Q=="
     },
     "install": {
       "version": "0.0.181",


### PR DESCRIPTION
New `neon` commands:
- New command: list-platforms: display the full expanded platform/target mapping for this project
- New command: current-platform: display the current device's platform (optionally as JSON)
- Deprecate rust-target