### PR TITLE
[cleanup] replace deprecated `.targets` in `load.cts`

### DIFF
--- a/test/integration/sniff-bytes/ts/load.cts
+++ b/test/integration/sniff-bytes/ts/load.cts
@@ -1,5 +1,5 @@
 module.exports = require('@neon-rs/load').proxy({
-  targets: {
+  platforms: {
     'linux-x64-gnu': () => require('@sniff-bytes/linux-x64-gnu'),
     'darwin-arm64': () => require('@sniff-bytes/darwin-arm64')
   },


### PR DESCRIPTION
Cleanup: `sniff-bytes` `load.cts` uses `.platforms` instead of deprecated `.targets`.