### PR TITLE
Special case for `neon add-platform` with empty `.neon.platforms`

### DIFF
--- a/pkgs/cli/index.js
+++ b/pkgs/cli/index.js
@@ -46820,6 +46820,11 @@ class LibraryManifest extends AbstractManifest {
             platformsSrc.push(preset);
             return this.addPlatforms(expandPlatformFamily(preset));
         }
+        // Edge case: an empty object can be treated like an empty array
+        if (Object.keys(platformsSrc).length === 0) {
+            this.cfg().platforms = [];
+            return await this.addPlatformPreset(preset);
+        }
         return this.addPlatforms(expandPlatformFamily(preset), { platformsSrc });
     }
     async updateTargets(log, bundle) {

--- a/src/cli/src/manifest.ts
+++ b/src/cli/src/manifest.ts
@@ -600,6 +600,12 @@ export class LibraryManifest extends AbstractManifest {
       return this.addPlatforms(expandPlatformFamily(preset));
     }
 
+    // Edge case: an empty object can be treated like an empty array
+    if (Object.keys(platformsSrc).length === 0) {
+      this.cfg().platforms = [];
+      return await this.addPlatformPreset(preset);
+    }
+
     return this.addPlatforms(expandPlatformFamily(preset), { platformsSrc });
   }
 


### PR DESCRIPTION
Edge case: when `.neon.platforms` is empty, `neon add-platform` with a preset works the same for either empty `[]` or empty `{}`.