### PR TITLE
`NEON_BUILD_PLATFORM` (part 1)

### DIFF
--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {

--- a/src/manifest/src/cache/cache.cts
+++ b/src/manifest/src/cache/cache.cts
@@ -6,6 +6,7 @@ export interface CacheCfg {
 
   hasUnsavedChanges(): boolean;
   setPlatformTarget(platform: NodePlatform, target: RustTarget): Promise<void>;
+  getPlatformOutputPath(platform: NodePlatform): string | undefined;
   updatePlatforms(lib: LibraryManifest): boolean;
   saveChanges(log: (msg: string) => void): Promise<void>;
 }

--- a/src/manifest/src/cache/npm/npm.cts
+++ b/src/manifest/src/cache/npm/npm.cts
@@ -30,6 +30,12 @@ export class NPMCacheCfg implements CacheCfg {
     this._packages = packages;
   }
 
+  getPlatformOutputPath(platform: NodePlatform): string | undefined {
+    return this._packages[platform]
+      ? path.join(this.dir, platform, 'index.node')
+      : undefined;
+  }
+
   async setPlatformTarget(platform: NodePlatform, target: RustTarget): Promise<void> {
     const pkg = this._packages[platform];
 
@@ -113,8 +119,7 @@ export class NPMCacheCfg implements CacheCfg {
         return js.objectExpression([...p.value.properties, ...newProps]);
       })
       .toSource({ quote: 'single' });
-    await fs.writeFile(loaderPath, result, 'utf8');
-  }
+    await fs.writeFile(loaderPath, result, 'utf8');  }
 
   packageNames(): string[] {
     const cfg = this.manifest.cfg();

--- a/src/manifest/src/library/library.cts
+++ b/src/manifest/src/library/library.cts
@@ -187,4 +187,10 @@ export class LibraryManifest extends AbstractManifest {
       this._updatedPlatforms = true;
     }
   }
+
+  getPlatformOutputPath(platform: NodePlatform): string | undefined {
+    return this._cacheCfg
+      ? this._cacheCfg.getPlatformOutputPath(platform)
+      : undefined;
+  }
 }


### PR DESCRIPTION
This is the first part of adding support for a `NEON_BUILD_PLATFORM` environment variable to `neon dist`. It adds functionality to the `@neon-rs/manifest` library, specifically a `LibraryManifest::getPlatformOutputPath()` method, which delegates to the cache config to determine the path to a specific platform's output index.node file. The new functionality for the CLI will be in a followup PR.
