### PR TITLE
`NEON_BUILD_PLATFORM`, part 2

### DIFF
--- a/dist/cli/package.json
+++ b/dist/cli/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/dherman/neon-rs#readme",
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.24",
-    "@cargo-messages/darwin-arm64": "0.0.202",
-    "@cargo-messages/darwin-x64": "0.0.202",
-    "@cargo-messages/linux-arm-gnueabihf": "0.0.202",
-    "@cargo-messages/linux-x64-gnu": "0.0.202",
-    "@cargo-messages/win32-arm64-msvc": "0.0.202",
-    "@cargo-messages/win32-x64-msvc": "0.0.202"
+    "@cargo-messages/android-arm-eabi": "0.1.26",
+    "@cargo-messages/darwin-arm64": "0.1.26",
+    "@cargo-messages/darwin-x64": "0.1.26",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.26",
+    "@cargo-messages/linux-x64-gnu": "0.1.26",
+    "@cargo-messages/win32-arm64-msvc": "0.1.26",
+    "@cargo-messages/win32-x64-msvc": "0.1.26"
   }
 }

--- a/dist/package-lock.json
+++ b/dist/package-lock.json
@@ -20,22 +20,22 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.24",
-        "@cargo-messages/darwin-arm64": "0.0.202",
-        "@cargo-messages/darwin-x64": "0.0.202",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.202",
-        "@cargo-messages/linux-x64-gnu": "0.0.202",
-        "@cargo-messages/win32-arm64-msvc": "0.0.202",
-        "@cargo-messages/win32-x64-msvc": "0.0.202"
+        "@cargo-messages/android-arm-eabi": "0.1.26",
+        "@cargo-messages/darwin-arm64": "0.1.26",
+        "@cargo-messages/darwin-x64": "0.1.26",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.26",
+        "@cargo-messages/linux-x64-gnu": "0.1.26",
+        "@cargo-messages/win32-arm64-msvc": "0.1.26",
+        "@cargo-messages/win32-x64-msvc": "0.1.26"
       }
     },
     "install": {
       "version": "0.1.26"
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.24.tgz",
-      "integrity": "sha512-FdiAry7eaLVtAbdnS+nFwIzMpiLQDReHbuUvlDb49apCQkyKS0mT9yvdDurhomvaTjOVNxwrJ/viWSvcpklyPg==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.26.tgz",
+      "integrity": "sha512-5ojo7ahugB16jGhcPQx1DscbvRrX71RB7ma/qKh4BAaNcw+wjzEj8ZWt+i02YevH+aalqBi4QKgbzHWKAS2bSw==",
       "cpu": [
         "arm"
       ],
@@ -45,9 +45,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.202.tgz",
-      "integrity": "sha512-urp6Jb/XCYRi3IBQqq5IHd52mh/zhu1w3b0Pq0XrY3+5SVLxYvnXCm2EL5l+Qn/RK9kWgt47RObRLyRcWvZduQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.26.tgz",
+      "integrity": "sha512-BKStfgN4hWMIQDi54E5hH1EtR0gtFAEBNclOGCHEQdL8PciXC9Hufv0LqQAVZcztVNs7rEQ9al8SRtfMXscvQA==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.202.tgz",
-      "integrity": "sha512-ZzR8/nsW9JVpsSSy4d0sSwgX62f1KI+QLGLTXXK4Zk1LZFaNV9yYXopMj0gZf66X983+7xog4mz6nC1cxTuvgA==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.26.tgz",
+      "integrity": "sha512-WLNhTlVOv46xbw99lup73t5W7Y7ZMlSASxEf6uSPlBnIG8F8Vx/uy6u7/D5r9bLP1WvjqJ6Qo7mDK2GbUR7YOg==",
       "cpu": [
         "x64"
       ],
@@ -69,9 +69,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.202.tgz",
-      "integrity": "sha512-/bBWfobLO164tnAAs8wFGD/JIxvyJuFO3ednSEpbpGqI1WhadizlnaxEYoc/+mfurCUbI3r1vXu2WgccSa7djw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.26.tgz",
+      "integrity": "sha512-NzS8g2fzqkYxqDBKztlHj7UfyVvU1+v4JgiB46SyXTA24G5pelNQ1aqOPQ1ghkSi11r8FgBUmT0AWSLAkkcFLg==",
       "cpu": [
         "arm"
       ],
@@ -81,9 +81,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.202.tgz",
-      "integrity": "sha512-2UziBk+RDAJ4g3QunjVTxTb4ZcjndSiaQyyJ1ifc0C9pDsyUNsTH7NRkSxTwnHFZS/B63xK//wTqvl2NWjEpSw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.26.tgz",
+      "integrity": "sha512-fQbu40626NYNLUSiYOouA11LwJ50h8jOhlb2NQIMoreCnOYhJBlsSGn7jRlPTWO3MMnqv1SlXhIRWLRRv74Gvg==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.202.tgz",
-      "integrity": "sha512-gd1/v6qF4y3m+YMAtafUEcaWn5CMC2aVdVG0jqZrXLHOD6h5+411/J+m1M3la02FurxunXOFhQehoCylluKrwQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.26.tgz",
+      "integrity": "sha512-lI/vkv2mT2qBfMZj/VubXtF4TbC1Rlou2SLUVhN1Nj+xb0BquyyWSJYVrRcareUlPwvxOmF9FcT2ZVxn2W2YbA==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +105,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.202.tgz",
-      "integrity": "sha512-bubK+1nWFXw9/NNxYqWYQOTFvkOJRSrHhdDL88MoMojd3CUpH8czciz+ri9G+HDQhBXaVnLUfO72x9OHBKwc7A==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.26.tgz",
+      "integrity": "sha512-FAM6tIq1Bi2nwCu+m5tQFczjbz/PLSwmljTSbjpqELEq0wXXp35ir7tdeNkIomDPUvNhEtSViTRZamBylphNSw==",
       "cpu": [
         "x64"
       ],

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -53,8 +53,8 @@
   },
   "dependencies": {
     "@neon-rs/load": "^0.0.181",
-    "@neon-rs/manifest": "^0.0.4",
-    "cargo-messages": "^0.1.24",
+    "@neon-rs/manifest": "^0.0.5",
+    "cargo-messages": "^0.1.26",
     "chalk": "^5.2.0",
     "command-line-args": "^5.2.1",
     "command-line-commands": "^3.0.2",
@@ -65,12 +65,12 @@
     "temp": "^0.9.4"
   },
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.24",
-    "@cargo-messages/darwin-arm64": "0.0.202",
-    "@cargo-messages/darwin-x64": "0.0.202",
-    "@cargo-messages/linux-arm-gnueabihf": "0.0.202",
-    "@cargo-messages/linux-x64-gnu": "0.0.202",
-    "@cargo-messages/win32-arm64-msvc": "0.0.202",
-    "@cargo-messages/win32-x64-msvc": "0.0.202"
+    "@cargo-messages/android-arm-eabi": "0.1.26",
+    "@cargo-messages/darwin-arm64": "0.1.26",
+    "@cargo-messages/darwin-x64": "0.1.26",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.26",
+    "@cargo-messages/linux-x64-gnu": "0.1.26",
+    "@cargo-messages/win32-arm64-msvc": "0.1.26",
+    "@cargo-messages/win32-x64-msvc": "0.1.26"
   }
 }

--- a/src/cli/src/commands/dist.ts
+++ b/src/cli/src/commands/dist.ts
@@ -3,6 +3,8 @@ import { copyFile } from 'node:fs/promises';
 import commandLineArgs from 'command-line-args';
 import { Command, CommandDetail, CommandSection } from '../command.js';
 import { CargoMessages, CargoReader } from 'cargo-messages';
+import { LibraryManifest } from '@neon-rs/manifest';
+import { assertIsNodePlatform } from '@neon-rs/manifest/platform';
 
 // FIXME: add options to infer crate name from manifests
 // --package <path/to/package.json>
@@ -13,7 +15,9 @@ const OPTIONS = [
   { name: 'log', alias: 'l', type: String, defaultValue: null },
   { name: 'mount', alias: 'm', type: String, defaultValue: null },
   { name: 'manifest-path', type: String, defaultValue: null },
-  { name: 'out', alias: 'o', type: String, defaultValue: null },
+  { name: 'out', alias: 'o', type: String, defaultValue: null }, // DEPRECATED: 0.2
+  { name: 'platform', alias: 'p', type: String, defaultValue: null },
+  { name: 'debug', alias: 'd', type: Boolean, defaultValue: false },
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
 
@@ -32,20 +36,52 @@ function ensureDefined(str: string | undefined, msg: string): string {
   return str;
 }
 
+function parseOutputFile(debug: boolean, out: string | undefined, platform: string | undefined): Promise<string> {
+  if (debug && out) {
+    throw new Error("Options --debug and --out cannot both be enabled.");
+  } else if (debug && platform) {
+    throw new Error("Options --debug and --platform cannot both be enabled.");
+  } else if (out && platform) {
+    throw new Error("Options --out and --platform cannot both be enabled.");
+  }
+
+  const NEON_DIST_OUTPUT = process.env['NEON_DIST_OUTPUT'];
+  const NEON_BUILD_PLATFORM = process.env['NEON_BUILD_PLATFORM'];
+
+  if (platform || (!debug && NEON_BUILD_PLATFORM)) {
+    const p = platform || NEON_BUILD_PLATFORM;
+    assertIsNodePlatform(p);
+    return LibraryManifest.load().then(manifest => {
+      const path = manifest.getPlatformOutputPath(p);
+      if (!path) {
+        throw new Error(`Platform $p not supported by this library.`);
+      }
+      return path;
+    });
+  } else if (out || (!debug && NEON_DIST_OUTPUT)) {
+    const path = out || NEON_DIST_OUTPUT;
+    return Promise.resolve(path!);
+  } else {
+    return Promise.resolve('index.node');
+  }
+}
+
 export default class Dist implements Command {
   static summary(): string { return 'Generate a binary .node file from a cargo output log.'; }
-  static syntax(): string { return 'neon dist [-n <name>] [-f <dylib>|[-l <log>] [-m <path>]] [-o <dist>]'; }
+  static syntax(): string { return 'neon dist [-n <name>] [-f <file>|[-l <log>] [-m <path>]] [-p <platform> | -d]'; }
   static options(): CommandDetail[] {
     return [
       { name: '-n, --name', summary: 'Crate name. (Default: $npm_package_name)' },
-      { name: '-f, --file <dylib>', summary: 'Build .node from dylib file <dylib>.' },
+      { name: '-f, --file <file>', summary: 'Build .node from dylib file <file>.' },
       { name: '-l, --log <log>', summary: 'Find dylib path from cargo messages <log>. (Default: stdin)' },
       {
         name: '-m, --mount <path>',
         summary: 'Mounted path of target directory in virtual filesystem. This is used to map paths from the log data back to their real paths, needed when tools such as cross-rs report messages from within a mounted Docker filesystem.'
       },
       { name: '--manifest-path <path>', summary: 'Real path to Cargo.toml. (Default: cargo behavior)' },
-      { name: '-o, --out <dist>', summary: 'Copy output to file <dist>. (Default: $NEON_DIST_OUTPUT or index.node)' },
+      // { name: '-o, --out <dist>', summary: 'Copy output to file <dist>. (Default: $NEON_DIST_OUTPUT or index.node)' },
+      { name: '-p, --platform <platform>', summary: 'Stage output file for caching to platform <platform>. (Default: $NEON_BUILD_PLATFORM or -d)' },
+      { name: '-d, --debug', summary: 'Generate output file for debugging (./index.node)' },
       { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
     ];
   }
@@ -62,7 +98,7 @@ export default class Dist implements Command {
   private _mount: string | null;
   private _manifestPath: string | null;
   private _crateName: string;
-  private _out: string;
+  private _out: Promise<string>;
   private _verbose: boolean;
 
   constructor(argv: string[]) {
@@ -86,9 +122,7 @@ export default class Dist implements Command {
     this._manifestPath = options['manifest-path'];
     this._crateName = options.name ||
       basename(ensureDefined(process.env['npm_package_name'], '$npm_package_name'));
-    this._out = options.out ||
-      process.env['NEON_DIST_OUTPUT'] ||
-      'index.node';
+    this._out = parseOutputFile(options.debug, options.out, options.platform);
     this._verbose = !!options.verbose;
 
     this.log(`crate name = "${this._crateName}"`);
@@ -147,6 +181,6 @@ export default class Dist implements Command {
     const file = this._file || (await this.findArtifact());
 
     // FIXME: needs all the logic of cargo-cp-artifact (timestamp check, M1 workaround, async, errors)
-    await copyFile(file, this._out);
+    await copyFile(file, await this._out);
   }
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -30,8 +30,8 @@
       "license": "MIT",
       "dependencies": {
         "@neon-rs/load": "^0.0.181",
-        "@neon-rs/manifest": "^0.0.4",
-        "cargo-messages": "^0.1.24",
+        "@neon-rs/manifest": "^0.0.5",
+        "cargo-messages": "^0.1.26",
         "chalk": "^5.2.0",
         "command-line-args": "^5.2.1",
         "command-line-commands": "^3.0.2",
@@ -57,19 +57,19 @@
         "typescript": "^5.0.4"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.24",
-        "@cargo-messages/darwin-arm64": "0.0.202",
-        "@cargo-messages/darwin-x64": "0.0.202",
-        "@cargo-messages/linux-arm-gnueabihf": "0.0.202",
-        "@cargo-messages/linux-x64-gnu": "0.0.202",
-        "@cargo-messages/win32-arm64-msvc": "0.0.202",
-        "@cargo-messages/win32-x64-msvc": "0.0.202"
+        "@cargo-messages/android-arm-eabi": "0.1.26",
+        "@cargo-messages/darwin-arm64": "0.1.26",
+        "@cargo-messages/darwin-x64": "0.1.26",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.26",
+        "@cargo-messages/linux-x64-gnu": "0.1.26",
+        "@cargo-messages/win32-arm64-msvc": "0.1.26",
+        "@cargo-messages/win32-x64-msvc": "0.1.26"
       }
     },
     "cli/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.24.tgz",
-      "integrity": "sha512-FdiAry7eaLVtAbdnS+nFwIzMpiLQDReHbuUvlDb49apCQkyKS0mT9yvdDurhomvaTjOVNxwrJ/viWSvcpklyPg==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.26.tgz",
+      "integrity": "sha512-5ojo7ahugB16jGhcPQx1DscbvRrX71RB7ma/qKh4BAaNcw+wjzEj8ZWt+i02YevH+aalqBi4QKgbzHWKAS2bSw==",
       "cpu": [
         "arm"
       ],
@@ -79,9 +79,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.0.202.tgz",
-      "integrity": "sha512-urp6Jb/XCYRi3IBQqq5IHd52mh/zhu1w3b0Pq0XrY3+5SVLxYvnXCm2EL5l+Qn/RK9kWgt47RObRLyRcWvZduQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.26.tgz",
+      "integrity": "sha512-BKStfgN4hWMIQDi54E5hH1EtR0gtFAEBNclOGCHEQdL8PciXC9Hufv0LqQAVZcztVNs7rEQ9al8SRtfMXscvQA==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.0.202.tgz",
-      "integrity": "sha512-ZzR8/nsW9JVpsSSy4d0sSwgX62f1KI+QLGLTXXK4Zk1LZFaNV9yYXopMj0gZf66X983+7xog4mz6nC1cxTuvgA==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.26.tgz",
+      "integrity": "sha512-WLNhTlVOv46xbw99lup73t5W7Y7ZMlSASxEf6uSPlBnIG8F8Vx/uy6u7/D5r9bLP1WvjqJ6Qo7mDK2GbUR7YOg==",
       "cpu": [
         "x64"
       ],
@@ -103,9 +103,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.0.202.tgz",
-      "integrity": "sha512-/bBWfobLO164tnAAs8wFGD/JIxvyJuFO3ednSEpbpGqI1WhadizlnaxEYoc/+mfurCUbI3r1vXu2WgccSa7djw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.26.tgz",
+      "integrity": "sha512-NzS8g2fzqkYxqDBKztlHj7UfyVvU1+v4JgiB46SyXTA24G5pelNQ1aqOPQ1ghkSi11r8FgBUmT0AWSLAkkcFLg==",
       "cpu": [
         "arm"
       ],
@@ -115,9 +115,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.0.202.tgz",
-      "integrity": "sha512-2UziBk+RDAJ4g3QunjVTxTb4ZcjndSiaQyyJ1ifc0C9pDsyUNsTH7NRkSxTwnHFZS/B63xK//wTqvl2NWjEpSw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.26.tgz",
+      "integrity": "sha512-fQbu40626NYNLUSiYOouA11LwJ50h8jOhlb2NQIMoreCnOYhJBlsSGn7jRlPTWO3MMnqv1SlXhIRWLRRv74Gvg==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.0.202.tgz",
-      "integrity": "sha512-gd1/v6qF4y3m+YMAtafUEcaWn5CMC2aVdVG0jqZrXLHOD6h5+411/J+m1M3la02FurxunXOFhQehoCylluKrwQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.26.tgz",
+      "integrity": "sha512-lI/vkv2mT2qBfMZj/VubXtF4TbC1Rlou2SLUVhN1Nj+xb0BquyyWSJYVrRcareUlPwvxOmF9FcT2ZVxn2W2YbA==",
       "cpu": [
         "arm64"
       ],
@@ -139,9 +139,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.0.202.tgz",
-      "integrity": "sha512-bubK+1nWFXw9/NNxYqWYQOTFvkOJRSrHhdDL88MoMojd3CUpH8czciz+ri9G+HDQhBXaVnLUfO72x9OHBKwc7A==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.26.tgz",
+      "integrity": "sha512-FAM6tIq1Bi2nwCu+m5tQFczjbz/PLSwmljTSbjpqELEq0wXXp35ir7tdeNkIomDPUvNhEtSViTRZamBylphNSw==",
       "cpu": [
         "x64"
       ],
@@ -156,93 +156,21 @@
       "integrity": "sha512-teRPDgstiKQE91WsvnW4mAdTSEPUdi9a8b98IPVhm2R5MT1elzxeTFidP56JfqtzocZFYDetCwEcPB3xCIR4pg=="
     },
     "cli/node_modules/cargo-messages": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.24.tgz",
-      "integrity": "sha512-fIPL1bL9jzE6GEh86KfWQNyhebnX0h3TaZpy+/qH+O6ts04BvFTlFsEEmCpzDuxelwszOv1KBLQ8ZL2aY8R8dw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.26.tgz",
+      "integrity": "sha512-qbYgL8iQOf9KrsorMHxe8K5rEVMtnmumqtGP/JWykDyYNw6snk2q1skd/8IEd0d/27o1WHDppRfK62FBDG5Uig==",
       "dependencies": {
         "@neon-rs/load": "^0.1.17"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.24",
-        "@cargo-messages/darwin-arm64": "0.1.24",
-        "@cargo-messages/darwin-x64": "0.1.24",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.24",
-        "@cargo-messages/linux-x64-gnu": "0.1.24",
-        "@cargo-messages/win32-arm64-msvc": "0.1.24",
-        "@cargo-messages/win32-x64-msvc": "0.1.24"
+        "@cargo-messages/android-arm-eabi": "0.1.26",
+        "@cargo-messages/darwin-arm64": "0.1.26",
+        "@cargo-messages/darwin-x64": "0.1.26",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.26",
+        "@cargo-messages/linux-x64-gnu": "0.1.26",
+        "@cargo-messages/win32-arm64-msvc": "0.1.26",
+        "@cargo-messages/win32-x64-msvc": "0.1.26"
       }
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.24.tgz",
-      "integrity": "sha512-uoKaYzdVM39fp6aHGgLrkHiqmVOXiBH0oHlsYgiNkPumhr3hN7/+OUGKOE3+aap8OHPLYSgO/8V8VCCHqB0FTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.24.tgz",
-      "integrity": "sha512-tw1l3kGXaNv4sJIjIXg3vu67+PJ405SINCxqxF9efCcDWXa9O7JBswXgQ5LsKwJoyAv9KvmX5ndR6zLYDK+TjA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.24.tgz",
-      "integrity": "sha512-ehX3PRSoZ8L3hi42HzqJf6G783CCfV/ttVpSKxCmp5U0MyhOZxRpPca8PZ4jyh/wr9OpGcHRgQ1i2NwsqEcBSg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.24.tgz",
-      "integrity": "sha512-dx2E25omrH5TfiqORhQhJ7Wvp5chVPQzK6292mrwmqBEfoKdC43Lzl1vCA3/SmG8PbtAgATZc/MZLIl89rXuqg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.24.tgz",
-      "integrity": "sha512-W41zVvAbeAQnLTcvhLKn5PZhqv22vXzB02u82cS2InkeYkIwp1ZcN4Mysw0Fb9x57qprSkw8cFtCY8C7ilTXhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "cli/node_modules/cargo-messages/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.24.tgz",
-      "integrity": "sha512-muRyL97umI663fn7UNd+h4s2pbHSeqqyqtYPlRWWGOpvJ+ykRWo+7zFATCEThh+z2qOnEmam431EzMSzP9EaXw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "cli/node_modules/cargo-messages/node_modules/@neon-rs/load": {
       "version": "0.1.19",
@@ -1126,9 +1054,9 @@
       "integrity": "sha512-zRkipoCMyu5eFdusb5DOcId/8zC/6xtM9+cM1E93AWAQvlEX2+PqFiltz6Fk57f6iZ6ASWrpdyqlzzGUHS9pbw=="
     },
     "node_modules/@neon-rs/manifest": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.0.4.tgz",
-      "integrity": "sha512-gyul4RBV5qc/tgNisCs0+4GAholk2vcIB0vgegwKyIW3qNoCkrRKo46N9eSZfUf9RSVS7YBS8CVXLC0CasVJAQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.0.5.tgz",
+      "integrity": "sha512-1qZjL29UYBIax/yD6+Lt6o3QNqULakFGFWcrEwSXAlOmtgzvR/e5gpFjYDF31CvGnDoSzusFp2mlzWiYwXJ86w==",
       "dependencies": {
         "jscodeshift": "^0.15.1"
       }


### PR DESCRIPTION
This PR follows up on #45 by adding support for `NEON_BUILD_PLATFORM` and `--platform` to `neon dist`. It also deprecates `-o`.