### PR TITLE
`export * from './index.cjs';`

### DIFF
--- a/test/integration/sniff-bytes/ts/index.mts
+++ b/test/integration/sniff-bytes/ts/index.mts
@@ -1,1 +1,1 @@
-export { sniffBytes, FileFormat } from './index.cjs';
+export * from './index.cjs';

--- a/test/integration/test-sniff-bytes/src/main.test.ts
+++ b/test/integration/test-sniff-bytes/src/main.test.ts
@@ -1,7 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { describe, expect, test } from '@jest/globals';
-import { sniffBytes } from '@neon-integration-tests/sniff-bytes';
+import { sniffBytes, FileFormat } from '@neon-integration-tests/sniff-bytes';
+
+type FF = FileFormat;
 
 async function loadFixture(name: string) {
   return (await readFile(path.join('.', 'fixtures', name))).buffer;
@@ -10,7 +12,7 @@ async function loadFixture(name: string) {
 describe('main', () => {
   test('sniff JPEG bytes', async () => {
     const jpg = await loadFixture('pit-droids.jpg');
-    const metadata = sniffBytes(jpg);
+    const metadata: FF = sniffBytes(jpg);
     expect(metadata.shortName).toBe('JPEG');
     expect(metadata.mediaType).toBe('image/jpeg');
     expect(metadata.extension).toBe('jpg');
@@ -18,7 +20,7 @@ describe('main', () => {
 
   test('sniff GIF bytes', async () => {
     const gif = await loadFixture('squirrel.gif');
-    const metadata = sniffBytes(gif);
+    const metadata: FF = sniffBytes(gif);
     expect(metadata.shortName).toBe('GIF');
     expect(metadata.mediaType).toBe('image/gif');
     expect(metadata.extension).toBe('gif');


### PR DESCRIPTION
Experiment: Can we do `export * from './index.cjs';` to avoid boilerplate?