### PR TITLE
Final newline when saving manifests

### DIFF
--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {

--- a/src/manifest/src/util.cts
+++ b/src/manifest/src/util.cts
@@ -64,7 +64,11 @@ export abstract class AbstractManifest {
   get description(): string { return (this._json as any).description ?? ""; }
 
   async save(log: (msg: string) => void): Promise<void> {
-    await fs.writeFile(path.join(this.dir, "package.json"), JSON.stringify(this._json, null, 2), { encoding: 'utf8' });
+    await fs.writeFile(
+      path.join(this.dir, "package.json"),
+      JSON.stringify(this._json, null, 2) + "\n",
+      { encoding: 'utf8' }
+    );
   }
 
   stringify(): string {


### PR DESCRIPTION
@neon-rs/manifest: Add a final newline when saving a manifest to disk.